### PR TITLE
Add email confirming places for SR2019

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,3 +1,3 @@
-Kickstart
+kickstart
 10am
 5pm

--- a/SR2019/2018-10-10-place-confirmation.md
+++ b/SR2019/2018-10-10-place-confirmation.md
@@ -1,0 +1,11 @@
+---
+to: Student Robotics 2019
+subject: SR2019 Registration and Kickstart Announcement
+note: This email will be sent multiple times, to those in the list not in the "Contacted" segment
+---
+
+You're in! This email is a confirmation of your teams place at Student Robotics 2019. We are unable to confirm second teams until our deadline of the 26th, due to the space constraints of the venue.
+
+The specific details for the London kickstart will be sent over soon to those who have requested the London venue. The Southampton venue (University of Southampton) will be available to all other teams.
+
+We look forward to seeing you there!

--- a/SR2019/2018-10-10-place-confirmation.md
+++ b/SR2019/2018-10-10-place-confirmation.md
@@ -1,11 +1,11 @@
 ---
 to: Student Robotics 2019
-subject: SR2019 Registration and Kickstart Announcement
+subject: Confirming your place at Student Robotics 2019
 note: This email will be sent multiple times, to those in the list not in the "Contacted" segment
 ---
 
-You're in! This email is a confirmation of your teams place at Student Robotics 2019. We are unable to confirm second teams until our deadline of the 26th, due to the space constraints of the venue.
+You're in! We're happy to confirm you've got a place at Student Robotics 2019! If you've applied for a second team, we sadly can't confirm you will receive a second kit until our deadline on the 26th.
 
-The specific details for the London kickstart will be sent over soon to those who have requested the London venue. The Southampton venue (University of Southampton) will be available to all other teams.
+The specific details for the London kickstart will be sent over soon to those who have requested the London venue. The London venue is small, and so we're only able to handle a small number of teams. Please only go to this venue if you've been confirmed. The Southampton venue (University of Southampton) will be available to all other teams.
 
 We look forward to seeing you there!

--- a/SR2019/2018-10-10-place-confirmation.md
+++ b/SR2019/2018-10-10-place-confirmation.md
@@ -8,4 +8,6 @@ You're in! We're happy to confirm you've got a place at Student Robotics 2019! I
 
 The specific details for the London kickstart will be sent over soon to those who have requested the London venue. The London venue is small, and so we're only able to handle a small number of teams. Please only go to this venue if you've been confirmed. The Southampton venue (University of Southampton) will be available to all other teams.
 
+To those who are unable to attend, worry not! Details on kit shipment will be coming through soon. The rules will be put live on the website during kickstart, so you won't miss out any planning time!
+
 We look forward to seeing you there!


### PR DESCRIPTION
Whilst this email is dated, it'll be sent multiple times. There's currently a pre-defined segment in MailChimp containing the current list of users, based on the date they were added to the list (which for all of them is today). These will be sent this when it's available. I'll then check the list every week, and send the email to those recently signed up outside the segment, and shift the segment threshold.

The wording will be the same in all the emails, besides the London kickstart email, which may have been sent by the time we send subsequent emails.