### PR TITLE
Add emails about confirming teams kickstart locations

### DIFF
--- a/SR2019/2018-10-30-kickstart-confirmation.md
+++ b/SR2019/2018-10-30-kickstart-confirmation.md
@@ -1,0 +1,16 @@
+---
+to: Student Robotics 2019
+subject: Confirming your place at Student Robotics Kickstart 2019
+---
+
+Hello!
+
+We'd like to confirm your place at the kickstart event for Student Robotics 2019. Here, we will announce the game, and show you how to use the kit.
+
+Due to size constraints on the venues, and ensuring your kit is at the right venue, please only attend the venue you've been invited to.
+
+Your Kickstart Venue: *|MMERGE6|*
+
+Information about the kickstart venues is available [on our website](https://studentrobotics.org/news/2018-10-14-sr2019-places-confimed-and-kickstart-details/).If you are unable to attend a kickstart event, the kit will be shipped to you. Instructions for this will follow. The rules will go live on our website during the games presentation, so be sure to keep eye on that so you don't miss out!
+
+If you have any other questions, please let us know!


### PR DESCRIPTION
Closes https://github.com/srobo/tasks/issues/6

Add an email to confirm kickstart locations, and remind them where information is for the venues.

__Note__: `*|MMERGE6|*` is the mailchimp template variable for their kickstart preference.