### PR TITLE
Add email to get kit disclaimer from teams

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -2,3 +2,4 @@ kickstart
 10am
 5pm
 75mm
+SKL_ADDR

--- a/SR2019/2018-11-19-kit-disclaimer.md
+++ b/SR2019/2018-11-19-kit-disclaimer.md
@@ -5,7 +5,7 @@ subject: Receiving your kit
 
 Hello there!
 
-As you were unable to attend kickstart, we need to ship you your kit. Before this can happen, we need you to sign a disclaimer.
+As you were unable to attend kickstart, we need to ship you your kit. Before this can happen, we need you to sign a disclaimer. This disclaimer covers the terms and conditions under which you may use the kit and outlines the limits of our responsibilities.
 
 As it's a legal document, please print out and sign the disclaimer form below, and email it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. If this address is incorrect, please let us know.
 

--- a/SR2019/2018-11-19-kit-disclaimer.md
+++ b/SR2019/2018-11-19-kit-disclaimer.md
@@ -1,0 +1,18 @@
+---
+to: Student Robotics 2019, didn't attend kickstart
+subject: Receiving your kit
+---
+
+Hello there!
+
+As you were unable to attend kickstart, we need to ship you your kit. Before this can happen, we need you to sign a disclaimer.
+
+As it's a legal document, please print out and sign the disclaimer form below, and send it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. If this address is incorrect, please let us know.
+
+Address:
+
+*|SKL_ADDR|*
+
+[Kit Disclaimer Form]()
+
+If you have any other questions, please let us know!

--- a/SR2019/2018-11-19-kit-disclaimer.md
+++ b/SR2019/2018-11-19-kit-disclaimer.md
@@ -7,7 +7,7 @@ Hello there!
 
 As you were unable to attend kickstart, we need to ship you your kit. Before this can happen, we need you to sign a disclaimer.
 
-As it's a legal document, please print out and sign the disclaimer form below, and send it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. If this address is incorrect, please let us know.
+As it's a legal document, please print out and sign the disclaimer form below, and email it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. If this address is incorrect, please let us know.
 
 Address:
 

--- a/SR2019/2018-11-19-kit-disclaimer.md
+++ b/SR2019/2018-11-19-kit-disclaimer.md
@@ -7,7 +7,7 @@ Hello there!
 
 As you were unable to attend kickstart, we need to ship you your kit. Before this can happen, we need you to sign a disclaimer. This disclaimer covers the terms and conditions under which you may use the kit and outlines the limits of our responsibilities.
 
-As it's a legal document, please print out and sign the disclaimer form below, and email it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. If this address is incorrect, please let us know.
+As it's a legal document, please print out and sign the disclaimer form below, and email it back to us. Once we have a release form for you, we'll send out your kit to the address listed below. Please let us know explicitly if this address is correct, and if it's not, let us know an updated one.
 
 Address:
 


### PR DESCRIPTION
The teams who didn't attend kickstart need their kit sent to them. The email will be sent to teams who  *don't* appear in https://github.com/srobo/inventory/tree/master/teams/2019 (which is the list of teams who have kits).

## The plan
1. Send this email
2. When a team responds, forward the email on to `trustees@`, to ensure they have a copy of the disclaimer. 
3. Validate the address we have for them is valid
4. Assign a kit we still have to the team
5. Work out how we're going to ship the kit (really only needs to happen once)
6. Send out the kit

Whether kit sending is going to happen in a couple waves, or as we receive kits needs to be organised with those in Southampton, where the kits currently reside. 

## To fill in before sending:
- The kit disclaimer form will be attacked to the email at the empty link
- Formatting around `SKL_ADDR` should be checked to make sure it looks ok