### PR TITLE
Add tech day announcement email

### DIFF
--- a/SR2019/2018-12-07-techday-announce.md
+++ b/SR2019/2018-12-07-techday-announce.md
@@ -17,6 +17,6 @@ These tech days will be at the Highfield campus, start around 10am, and finish a
 
 We would like to also run some tech days in London. If you would be interested in a tech day in London too on these dates, please let us know as soon as possible. For the December tech day, we need enough teams by the 12th to make it happen.
 
-Specific details for these tech days will be available on our website soon.
+Specific details for tech days will be available on our website soon.
 
 We hope to see many of you there!

--- a/SR2019/2018-12-07-techday-announce.md
+++ b/SR2019/2018-12-07-techday-announce.md
@@ -3,7 +3,7 @@ to: Student Robotics 2019
 subject: Announcing tech days
 ---
 
-As was announced at kickstart, we intend to run some tech days over this competition year. Tech days are opportunities for teams to get help if they’re struggling with a technical issue, and is a controlled environment for students to make more progress on their robots. It’s also an opportunity to see how well they’re doing in comparison to other teams.
+As was announced at kickstart, we intend to run some tech days over this competition year. Tech days are opportunities for teams to get help if they’re struggling with a technical issue, and is an environment for students to make more progress on their robots, with help from highly-experienced blue-shirts. It’s also an opportunity to see how well teams are doing in comparison to other teams.
 
 As with all other events, students *must* be accompanied by a responsible adult.
 

--- a/SR2019/2018-12-07-techday-announce.md
+++ b/SR2019/2018-12-07-techday-announce.md
@@ -1,0 +1,22 @@
+---
+to: Student Robotics 2019
+subject: Announcing tech days
+---
+
+As was announced at kickstart, we intend to run some tech days over this competition year. Tech days are opportunities for teams to get help if they’re struggling with a technical issue, and is a controlled environment for students to make more progress on their robots. It’s also an opportunity to see how well they’re doing in comparison to other teams.
+
+As with all other events, students *must* be accompanied by a responsible adult.
+
+We will be running tech days at the University of Southampton on the following days:
+
+- 15th December 2018
+- 9th February 2019
+- 9th March 2019
+
+These tech days will be at the Highfield campus, start around 10am, and finish around 5pm. However please turn up and leave whenever's appropriate.
+
+We would like to also run some tech days in London. If you would be interested in a tech day in London too on these dates, please let us know as soon as possible. For the December tech day, we need enough teams by the 12th to make it happen.
+
+Specific details for these tech days will be available on our website soon.
+
+We hope to see many of you there!

--- a/SR2019/2018-12-07-techday-announce.md
+++ b/SR2019/2018-12-07-techday-announce.md
@@ -7,7 +7,7 @@ As was announced at kickstart, we intend to run some tech days over this competi
 
 As with all other events, students *must* be accompanied by a responsible adult.
 
-We will be running tech days at the University of Southampton on the following days:
+We will be running tech days at the University of Southampton on the following Saturdays:
 
 - 15th December 2018
 - 9th February 2019


### PR DESCRIPTION
Announce tech days to teams. These dates have been provisionally booked in 25 by @Adimote. 

The email references pages on the website, so we should aim to get those up fairly soon, however I don't think that should block sending this email.