### PR TITLE
Add feb tech days email

### DIFF
--- a/SR2019/2019-01-28-feb-techday.md
+++ b/SR2019/2019-01-28-feb-techday.md
@@ -1,0 +1,21 @@
+---
+to: Student Robotics 2019
+subject: February tech day reminder
+---
+
+Hi all,
+
+Just a reminder and some information on the tech day we're running on on Saturday 9th February.
+
+Tech Days are opportunities for you to get help if you're struggling with a technical issue, and is a controlled environment to make more progress on your robots. It’s also an opportunity to see how well you're doing in comparison to other teams.
+
+We're running this tech day in 2 locations, London and Southampton. The day will run from 10am until 5pm, however feel free to come and go as you please.
+
+The London venue will only run of there is sufficient interest. Spaces are limited to six teams, so be sure to let us know if you’d like to attend.
+
+For event-specific details, please consult our website:
+
+[London Tech Day](https://studentrobotics.org/events/sr2019/london-tech-day-february/)
+[Southampton Tech Day](https://studentrobotics.org/events/sr2019/southampton-tech-day-february/)
+
+If you are unable to make this date, The next Tech Day after this will be 9th March.


### PR DESCRIPTION
Add email reminder about the February tech days. 

Information sourced from https://studentrobotics.org/events/sr2019/southampton-tech-day-february/ and https://studentrobotics.org/events/sr2019/london-tech-day-february/