### PR TITLE
Add lack of progress reminder email

### DIFF
--- a/SR2019/2019-02-25-lack-of-progress-reminder
+++ b/SR2019/2019-02-25-lack-of-progress-reminder
@@ -1,0 +1,12 @@
+---
+to: Student Robotics 2019 (Restricted to teams who haven't made any code edits since 2019)
+subject: Progress on your robot
+---
+
+Hey,
+
+We've noticed that your team hasn't made any changes to their code in the last couple of months, which is a possible indicator that your team may be struggling with making a robot.
+
+We always encourage you to push your team to get some kind of robot together, as a lot can be learned from the experience of putting together even the most basic robot, and it's a huge learning opportunity for them.
+
+You should try really really hard to make sure your team is making progress in preparation for the competition. However, we know there are situations where teams can't continue. In which case, there are some teams that would like to have a second kit. So please give us a shout and we can see if we can reallocate the kit to a team with two robots, but one kit.


### PR DESCRIPTION
Add a reminder email to send to teams who haven't written code this calendar year.