### PR TITLE
Add competition information email

### DIFF
--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -9,9 +9,9 @@ There's just 26 days between now and the competition, and we're getting the fina
 
 We have some final information for you for the competition.
 
-## Reduced mobility
+## Venue Layout
 
-The team pits for this year's competition are spread over 3 floors. If any members of your team have reduced mobility, please let us know as soon as possible so we can account for this when placing teams.
+The team pits for this year's competition are spread over 3 floors. If any members of your team have reduced mobility, or any other specific requirements which may impact the location of your team pit, please let us know as soon as possible so we can account for this when placing teams.
 
 ## Media Consent Form and Tickets
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -48,6 +48,10 @@ This number should only be used for this competition event and will only be answ
 
 With less than 4 weeks left until the final, we hope you're progressing well. The time left to get support is growing smaller, so if you're facing any issues, be sure to check the rules and the docs, they usually hold the answers! If you have any questions, please let us know on the forums, we try to answer them as quickly as possible.
 
+## Kit Loan Extension
+
+In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 31st March.
+
 We've also updated the [competition page](https://studentrobotics.org/events/sr2019/competition/) on our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 
 We look forward to seeing you at the competition. Good luck!

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -48,6 +48,6 @@ This number should only be used for this competition event and will only be answ
 
 With less than 4 weeks left until the final, we hope you're progressing well. The time left to get support is growing smaller, so if you're facing any issues, be sure to check the rules and the docs, they usually hold the answers! If you have any questions, please let us know on the forums, we try to answer them as quickly as possible.
 
-We've also updated our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
+We've also updated the [competition page](https://studentrobotics.org/events/sr2019/competition/) on our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 
 We look forward to seeing you at the competition. Good luck!

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -42,7 +42,7 @@ Some teams have asked for emergency contact information on our forums (https://s
 
 Contact number: <number>
 
-This number should only be used for this competition event.
+This number should only be used for this competition event and will only be answered on the day before and the during the event.
 
 
 We've also updated our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -29,7 +29,7 @@ Once your form has been processed, you'll receive an automated email response wi
 
 We recently made our first update to the rules. This contained some important, but minor changes:
 
-- Change the documented hashtag from `srobo2019` to `srobo19` to follow what was being used internally
+- Change the documented hashtag from `#srobo2019` to `#srobo19` to follow what was being used internally
 - Specify how we interpret whether a robot is in a zone
 - Add a regulation allowing supporting equipment
 - Clarify the wording of the scoring zones grid

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -44,6 +44,9 @@ Contact number: <number>
 
 This number should only be used for this competition event and will only be answered on the day before and the during the event.
 
+## Support
+
+With less than 4 weeks left until the final, we hope you're progressing well. The time left to get support is growing smaller, so if you're facing any issues, be sure to check the rules and the docs, they usually hold the answers! If you have any questions, please let us know on the forums, we try to answer them as quickly as possible.
 
 We've also updated our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -1,0 +1,50 @@
+---
+to: Student Robotics 2019
+subject: Competition Informatiom
+---
+
+Hi all,
+
+There's just 26 days between now and the competition, and we're getting the final things ready for Student Robotics 2019. We hope your robots are battle-ready, and you're well on your way to entering a robot capable of winning!
+
+We have some final information for you for the competition.
+
+## Reduced mobility
+
+The team pits for this year's competition are spread over 3 floors. If any members of your team have reduced mobility, please let us know as soon as possible so we can account for this when placing teams.
+
+## Media Consent Form and Tickets
+
+As with previous years, we require you to sign a media consent form. These media consent forms allow us to use videos and photographs taken at the event for future marketing purposes.
+
+[Download our Media Consent form]()
+
+If a member of your team is under the age of 16, they will need to get a parent or guardian to sign on their behalf.
+
+Once these forms have been completed, please send them to `teams@studentrobotics.org` with the word 'media-consent' in the subject line, to ensure they won't be missed. We will have media consent forms available at the event, but pre-processing them makes the reception process faster.
+
+Once your form has been processed, you'll receive an automated email response with your ticket. These tickets must be bought with you to the competition (printed or on a phone is fine).
+
+## Rules Update
+
+We recently made our first update to the rules. This contained some important, but minor changes:
+
+- Change the documented hashtag from `srobo2019` to `srobo19` to follow what was being used internally
+- Specify how we interpret whether a robot is in a zone
+- Add a regulation allowing supporting equipment
+- Clarify the wording of the scoring zones grid
+
+These rules are now available in the [docs](https://studentrobotics.org/docs/rules/).
+
+## Emergency contact information
+
+Some teams have asked for emergency contact information on our forums (https://studentrobotics.org/forum/viewtopic.php?f=9&t=46&p=201#p201). We now have a dedicated contact number for use at the event. This number should only be used by team leaders and college staff.
+
+Contact number: <number>
+
+This number should only be used for this competition event.
+
+
+We've also updated our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
+
+We look forward to seeing you at the competition. Good luck!

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -50,7 +50,7 @@ With less than 4 weeks left until the final, we hope you're progressing well. Th
 
 ## Kit Loan Extension
 
-In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. This year, we're allowing a loan extension until 4th May. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 22nd March.
+In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. This year, we're allowing a loan extension until 27th April, by which time they need to be back in our possession. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 22nd March.
 
 We've also updated the [competition page](https://studentrobotics.org/events/sr2019/competition/) on our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -5,7 +5,7 @@ subject: Competition Informatiom
 
 Hi all,
 
-There's just 26 days between now and the competition, and we're getting the final things ready for Student Robotics 2019. We hope your robots are battle-ready, and you're well on your way to entering a robot capable of winning!
+There's just 26 days between now and the competition, and we're getting the final things ready for Student Robotics 2019. We hope your robots are competition-ready, and you're well on your way to entering a robot capable of winning!
 
 We have some final information for you for the competition.
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -17,7 +17,7 @@ The team pits for this year's competition are spread over 3 floors. If any membe
 
 As with previous years, we require you to sign a media consent form. These media consent forms allow us to use videos and photographs taken at the event for future marketing purposes.
 
-[Download our Media Consent form]()
+[Download our Media Consent form](https://studentrobotics.org/resources/sr2019/media-consent.pdf)
 
 If a member of your team is under the age of 16, they will need to get a parent or guardian to sign on their behalf.
 
@@ -50,7 +50,7 @@ With less than 4 weeks left until the final, we hope you're progressing well. Th
 
 ## Kit Loan Extension
 
-In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 31st March.
+In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. This year, we're allowing a loan extension until 4th May. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 31st March.
 
 We've also updated the [competition page](https://studentrobotics.org/events/sr2019/competition/) on our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -34,7 +34,7 @@ We recently made our first update to the rules. This contained some important, b
 - Add a regulation allowing supporting equipment
 - Clarify the wording of the scoring zones grid
 
-These rules are now available in the [docs](https://studentrobotics.org/docs/rules/).
+The rules have been updated in the [docs](https://studentrobotics.org/docs/rules/).
 
 ## Emergency contact information
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -38,7 +38,7 @@ The rules have been updated in the [docs](https://studentrobotics.org/docs/rules
 
 ## Emergency contact information
 
-Some teams have asked for emergency contact information on our forums (https://studentrobotics.org/forum/viewtopic.php?f=9&t=46&p=201#p201). We have a dedicated contact number for use at the event. This number should only be used by team leaders and college staff.
+Some teams have asked for emergency contact information on our forums. We have a dedicated contact number for use at the event. This number should only be used by team leaders and college staff.
 
 Contact number: <number>
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -19,7 +19,7 @@ As with previous years, we require you to sign a media consent form. These media
 
 [Download our Media Consent form](https://studentrobotics.org/resources/sr2019/media-consent.pdf)
 
-If a member of your team is under the age of 16, they will need to get a parent or guardian to sign on their behalf.
+If a member of your team is under the age of 16, they will need to get a parent or guardian to sign on their behalf. Please put "Student Robotics 2019" as the event name.
 
 Once these forms have been completed, please send them to `teams@studentrobotics.org` with the word 'media-consent' in the subject line, to ensure they won't be missed. We will have media consent forms available at the event, but pre-processing them makes the reception process faster.
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -29,10 +29,10 @@ Once your form has been processed, you'll receive an automated email response wi
 
 We recently made our first update to the rules. This contained some important, but minor changes:
 
-- Change the documented hashtag from `#srobo2019` to `#srobo19` to follow what was being used internally
 - Specify how we interpret whether a robot is in a zone
 - Add a regulation allowing supporting equipment
 - Clarify the wording of the scoring zones grid
+- Change the documented hashtag from `#srobo2019` to `#srobo19` to follow what was being used internally
 
 The rules have been updated in the [docs](https://studentrobotics.org/docs/rules/).
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -21,7 +21,7 @@ As with previous years, we require you to sign a media consent form. These media
 
 If a member of your team is under the age of 16, they will need to get a parent or guardian to sign on their behalf. Please put "Student Robotics 2019" as the event name.
 
-Once these forms have been completed, please send them to `teams@studentrobotics.org` with the word 'media-consent' in the subject line, to ensure they won't be missed. We will have media consent forms available at the event, but pre-processing them makes the reception process faster.
+Once these forms have been completed, please send them to `teams@studentrobotics.org` with the word 'media-consent' in the subject line, to ensure they won't be missed. Additional media consent forms will be available at the event for additional guests.
 
 Once your form has been processed, you'll receive an automated email response with your ticket. These tickets must be brought with you to the competition (printed or on a phone is fine).
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -38,7 +38,7 @@ The rules have been updated in the [docs](https://studentrobotics.org/docs/rules
 
 ## Emergency contact information
 
-Some teams have asked for emergency contact information on our forums (https://studentrobotics.org/forum/viewtopic.php?f=9&t=46&p=201#p201). We now have a dedicated contact number for use at the event. This number should only be used by team leaders and college staff.
+Some teams have asked for emergency contact information on our forums (https://studentrobotics.org/forum/viewtopic.php?f=9&t=46&p=201#p201). We have a dedicated contact number for use at the event. This number should only be used by team leaders and college staff.
 
 Contact number: <number>
 

--- a/SR2019/2019-03-11-competition-information.md
+++ b/SR2019/2019-03-11-competition-information.md
@@ -50,7 +50,7 @@ With less than 4 weeks left until the final, we hope you're progressing well. Th
 
 ## Kit Loan Extension
 
-In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. This year, we're allowing a loan extension until 4th May. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 31st March.
+In the past, some teams have requested to hold on to the kit for a couple of weeks after the competition. This year, we're allowing a loan extension until 4th May. If this is something you would be interested, please let us know on `teams@studentrobotics.org`, with the reason you wish to hold on to the kit. The closing date for this is 22nd March.
 
 We've also updated the [competition page](https://studentrobotics.org/events/sr2019/competition/) on our website with more information on the venue and parking. We will keep updating this with more information, so be sure to keep an eye on it.
 


### PR DESCRIPTION
Add competition information email as described in https://github.com/srobo/core-team-minutes/issues/89. 

The contact number will be filled in at send time, so it's not public here for all time.

Requires: 
- https://github.com/srobo/docs/pull/92
- https://github.com/srobo/website/pull/136