### PR TITLE
Add first kit chaser email

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -13,3 +13,10 @@ Holles
 blueshirt
 YouTube
 livestream
+18l
+48cm
+39cm
+20cm
+6kg
+4.95kg
+100Wh

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -16,13 +16,13 @@ Please securely pack the kit and ship it to the address listed on [our website](
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.
 
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
+
 Kit data for couriers:
 
 - Dimensions: 48cm x 39cm x 20cm
 - Weight: 6kg
 - Value (for insurance): £500
 - Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
-
-Kit should be shipped using a courier which supports tracking, to ensure the kit isn't lost.
 
 If you have any questions, please let us know as soon as possible!

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -11,7 +11,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 
 ## How to ship your kit
 
-- Kits should be shipped in the white 18l Really Useful Box (RUB).
+- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / clingfilm during shipping.
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -19,7 +19,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 Kit data for couriers:
 
 - Dimensions: 48cm x 39cm x 20cm
-- Weight: 6kg (A kit weighs 4.95kg ref. 6kg gives some headroom)
+- Weight: 6kg
 - Value (for insurance): £500
 - Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
 

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -1,0 +1,28 @@
+---
+to: Teams with outstanding kit
+subject: Outstanding kit
+---
+
+Hello!
+
+According to our records, you still have a kit from this years competition. As the competition has ended, we would like this back!
+
+Please securely pack the kit and ship it to the address listed on our website: https://studentrobotics.org/contact/. Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
+
+## How to ship your kit
+
+- Kits should be shipped in the while 18l Really Useful Box (RUB).
+- All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
+- Damaged batteries must not be shipped.
+- Any empty space in the box should be filled with paper or bubble wrap. No packing peanuts; They're messy.
+
+Kit data for couriers:
+
+- Dimensions: 48cm x 39cm x 20cm
+- Weight: 6kg (A kit weighs 4.95kg ref. 6kg gives some headroom)
+- Value (for insurance): £500
+- Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
+
+Kit should be shipped using a courier which supports tracking, to ensure the kit isn't lost.
+
+If you have any questions, please let us know as soon as possible!

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -7,7 +7,7 @@ Hello!
 
 According to our records, you still have a kit from this years competition. As the competition has ended, we would like this back!
 
-Please securely pack the kit and ship it to the address listed on our website: https://studentrobotics.org/contact/. Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
+Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
 
 ## How to ship your kit
 

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -11,7 +11,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 
 ## How to ship your kit
 
-- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / clingfilm during shipping.
+- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -14,7 +14,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 - Kits should be shipped in the while 18l Really Useful Box (RUB).
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
-- Any empty space in the box should be filled with paper or bubble wrap. No packing peanuts; They're messy.
+- Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.
 
 Kit data for couriers:
 

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -11,7 +11,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 
 ## How to ship your kit
 
-- Kits should be shipped in the while 18l Really Useful Box (RUB).
+- Kits should be shipped in the white 18l Really Useful Box (RUB).
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.

--- a/SR2019/2019-05-15-kit-chase-round-1.md
+++ b/SR2019/2019-05-15-kit-chase-round-1.md
@@ -13,7 +13,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 
 - Kits should be shipped in the while 18l Really Useful Box (RUB).
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
-- Damaged batteries must not be shipped.
+- Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. No packing peanuts; They're messy.
 
 Kit data for couriers:


### PR DESCRIPTION
Some teams still have kits (~6), so we need to chase them up to get them back! This email intentionally doesn't list _which_ teams.

Taking inspiration from https://srobo.github.io/runbook/teams/after-competition/ and https://srobo-legacy.gitbooks.io/student-robotics-kit-logistics/content/kit-transport.html