### PR TITLE
Add custom email to chase up teams with single items of kit

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -20,3 +20,5 @@ livestream
 6kg
 4.95kg
 100Wh
+Alie
+Whitechapel

--- a/SR2019/2019-05-28-single-item-kit-chase.md
+++ b/SR2019/2019-05-28-single-item-kit-chase.md
@@ -1,0 +1,23 @@
+---
+to: Teams with outstanding single items of kit
+subject: Outstanding kit
+---
+
+Hello,
+
+According to our records, you still have some of our kit. As the competition has ended, we would like this back!
+
+At the end of the competition, we checked your kit in, and some items were missing. Below are the items we require back:
+
+## Missing items
+
+-
+-
+
+Please search anywhere you may have worked on your robot for these items. If you are unable to find any of these items, please [let us know](mailto:teams@studentrobotics.org).
+
+## Shipping items
+
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
+
+Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your school name is written on the outside of the packaging.

--- a/SR2019/2019-05-28-single-item-kit-chase.md
+++ b/SR2019/2019-05-28-single-item-kit-chase.md
@@ -20,4 +20,4 @@ Please search anywhere you may have worked on your robot for these items. If you
 
 Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
 
-Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your school name is written on the outside of the packaging.
+Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your TLA is written on the outside of the packaging.

--- a/SR2019/2019-05-28-single-item-kit-chase.md
+++ b/SR2019/2019-05-28-single-item-kit-chase.md
@@ -5,7 +5,7 @@ subject: Outstanding kit
 
 Hello,
 
-According to our records, you still have some of our kit. As the competition has ended, we would like this back!
+According to our records, you still have some items from the robot kit you borrowed during the SR2019 competition. As the competition has ended, we would like this back!
 
 At the end of the competition, we checked your kit in, and some items were missing. Below are the items we require back:
 

--- a/SR2019/2019-05-28-single-item-kit-chase.md
+++ b/SR2019/2019-05-28-single-item-kit-chase.md
@@ -18,10 +18,8 @@ Please search anywhere you may have worked on your robot for these items. If you
 
 ## Shipping items
 
-Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
-
-Please securely pack the kit and ship it to:
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost. Please securely pack the kit and ship it to the address below, ensuring your TLA is written on the outside of the packaging.
 
 1 Alie Street, Whitechapel, London, E1 8DE
 
-Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your TLA is written on the outside of the packaging.
+Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).

--- a/SR2019/2019-05-28-single-item-kit-chase.md
+++ b/SR2019/2019-05-28-single-item-kit-chase.md
@@ -20,4 +20,8 @@ Please search anywhere you may have worked on your robot for these items. If you
 
 Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
 
-Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your TLA is written on the outside of the packaging.
+Please securely pack the kit and ship it to:
+
+1 Alie Street, Whitechapel, London, E1 8DE
+
+Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org). Please ensure your TLA is written on the outside of the packaging.


### PR DESCRIPTION
After the competition, some teams were missing single items from their kits. We stored this list, but now it's time to ask for them back.

This email will be sent to teams with outstanding items which are inventorised. Uninventorised items are unlikely to be worth chasing. 

![image](https://user-images.githubusercontent.com/6527489/58368914-4a459800-7eeb-11e9-80c0-2e9f2203aaa3.png)

https://docs.google.com/spreadsheets/d/16w0fKgWRt39uisjXG1Xhbg6kdUbHte1n_gjSa4bfmQM/edit#gid=0

