### PR TITLE
Add round 2 chaser email

### DIFF
--- a/SR2019/2019-07-02-kit-chase-round-2.md
+++ b/SR2019/2019-07-02-kit-chase-round-2.md
@@ -27,4 +27,4 @@ Kit information for couriers:
 - Value (for insurance): £500
 - Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
 
-If we do not hear back within 2 weeks, we will be forced to take this higher. If you have any questions, please let us know as soon as possible!
+If we do not hear back within 2 weeks, we will be forced to contact the head of your school/organisation directly. If you have any questions, please let us know as soon as possible!

--- a/SR2019/2019-07-02-kit-chase-round-2.md
+++ b/SR2019/2019-07-02-kit-chase-round-2.md
@@ -20,7 +20,7 @@ Please securely pack the kit and ship it to the address listed on [our website](
 
 Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
 
-Kit data for couriers:
+Kit information for couriers:
 
 - Dimensions: 48cm x 39cm x 20cm
 - Weight: 6kg

--- a/SR2019/2019-07-02-kit-chase-round-2.md
+++ b/SR2019/2019-07-02-kit-chase-round-2.md
@@ -1,6 +1,6 @@
 ---
 to: Teams with still outstanding kit
-subject: Outstanding kit - Round 2
+subject: Outstanding kit from SR2019 (second followup)
 ---
 
 Hello!

--- a/SR2019/2019-07-02-kit-chase-round-2.md
+++ b/SR2019/2019-07-02-kit-chase-round-2.md
@@ -1,0 +1,30 @@
+---
+to: Teams with still outstanding kit
+subject: Outstanding kit - Round 2
+---
+
+Hello!
+
+We sent an email to you back in May stating we required a kit back from you. Unfortunately, we've not heard a response.
+
+The kits are loaned to you fur the duration of the competition year, and as this has ended, we need the kits back, to prepare for future events.
+
+Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
+
+## How to ship your kit
+
+- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
+- All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
+- Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
+- Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.
+
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
+
+Kit data for couriers:
+
+- Dimensions: 48cm x 39cm x 20cm
+- Weight: 6kg
+- Value (for insurance): £500
+- Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
+
+If we do not hear back within 2 weeks, we will be forced to take this higher. If you have any questions, please let us know as soon as possible!

--- a/SR2019/2019-07-02-kit-chase-round-2.md
+++ b/SR2019/2019-07-02-kit-chase-round-2.md
@@ -7,7 +7,7 @@ Hello!
 
 We sent an email to you back in May stating we required a kit back from you. Unfortunately, we've not heard a response.
 
-The kits are loaned to you fur the duration of the competition year, and as this has ended, we need the kits back, to prepare for future events.
+The kits are loaned to you fur the duration of the competition year, and as this has ended, we need the kits back to prepare for future events.
 
 Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
 


### PR DESCRIPTION
The logical extension of #21. Unfortunately, we still have `n` team kits unaccounted for. We therefore need a slightly sterner email to those teams to get the kits back to us.

The next step, as outlined in [the runbook](https://srobo.github.io/runbook/teams/after-competition/#write-to-the-organisation-associated-with-teams-who-dropped-out-without-notifying-sr-in-advance), is to contact senior members of the college directly.