### PR TITLE
Fully spell out these command line options

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "emails",
   "description": "A history of communication with teams.",
   "scripts": {
-    "test": "mdspell --en-gb -ranx 'SR**/*.md'"
+    "test": "mdspell --en-gb --ignore-numbers --ignore-acronyms --no-suggestions --report 'SR**/*.md'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is much clearer to readers without them needing to consult the docs for `mdspell`.