### PR TITLE
Add email sending out kit disclaimer form early

### DIFF
--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -15,6 +15,8 @@ Attached to this email is the disclaimer form. Please read it, print it, sign it
 
 Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know.
 
+Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums. Please check you can login and create competitors before kickstart.
+
 If you have any questions, please let us know as soon as possible.
 
 We look forward to seeing you all there!

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -1,0 +1,20 @@
+---
+to: sr2020-teams
+subject: Confirming Kickstart details
+attachments:
+  - https://drive.google.com/a/studentrobotics.org/file/d/1aCHnZ6o8DkLzHef1C2lz_iIkZkOjYP6P/view?usp=sharing
+---
+
+Hi all,
+
+Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we're currently working out the details for how to ship you your kit.
+
+Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but to speed things up, we're sending them over early, so you can get your kit quicker!
+
+Attached to this email is the disclaimer form. Please read it, print it, sign it, and [send it back to us](mailto:teams@studentrobotics.org). Alternatively, feel free to sign it and bring it with you. We will of course have some spares at the event to sign on the day.
+
+Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know!
+
+If you have any questions, please let us know as soon as possible!
+
+We look forward to seeing you all there!

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -9,12 +9,12 @@ Hi all,
 
 Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we'll contact you shortly to confirm details of shipping your kits.
 
-Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but to speed things up, we're sending them over early, so you can get your kit quicker!
+Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but to speed things up, we're sending them over early, so you can get your kit quicker.
 
 Attached to this email is the disclaimer form. Please read it, print it, sign it, and [send it back to us](mailto:teams@studentrobotics.org). Alternatively, feel free to sign it and bring it with you. We will of course have some spares at the event to sign on the day.
 
-Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know!
+Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know.
 
-If you have any questions, please let us know as soon as possible!
+If you have any questions, please let us know as soon as possible.
 
 We look forward to seeing you all there!

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -15,7 +15,7 @@ Attached to this email is the disclaimer form. Please read it, print it, sign it
 
 Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know.
 
-Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums. Please check you can login and create competitors before kickstart.
+Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums, which they'll need to use at kickstart. Please check you can login and create competitors before kickstart, and let us know if you have any problems.
 
 If you have any questions, please let us know as soon as possible.
 

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -9,7 +9,7 @@ Hi all,
 
 Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we'll contact you shortly to confirm details of shipping your kits.
 
-Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but to speed things up, we're sending them over early, so you can get your kit quicker.
+Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but we're sending them over early to speed up the issuing process on the day. If you're not attending Kickstart, return your form promptly to ensure you receive your kit as soon afterwards as possible.
 
 Attached to this email is the disclaimer form. Please read it, print it, sign it, and [send it back to us](mailto:teams@studentrobotics.org). Alternatively, feel free to sign it and bring it with you. We will of course have some spares at the event to sign on the day.
 

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -7,7 +7,7 @@ attachments:
 
 Hi all,
 
-Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we're currently working out the details for how to ship you your kit.
+Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we'll contact you shortly to confirm details of shipping your kits.
 
 Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but to speed things up, we're sending them over early, so you can get your kit quicker!
 

--- a/SR2020/2019-10-21-kit-disclaimer-form.md
+++ b/SR2020/2019-10-21-kit-disclaimer-form.md
@@ -1,6 +1,6 @@
 ---
 to: sr2020-teams
-subject: Confirming Kickstart details
+subject: Kit Disclaimer Forms
 attachments:
   - https://drive.google.com/a/studentrobotics.org/file/d/1aCHnZ6o8DkLzHef1C2lz_iIkZkOjYP6P/view?usp=sharing
 ---

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -24,3 +24,4 @@ Lastly, we will be [livestreaming the kickstart presentation](https://www.youtub
 If you have any questions, please let us know as soon as possible.
 
 We look forward to seeing you all there!
+

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -19,9 +19,8 @@ Please only attend the kickstart we're expecting you at: https://docs.google.com
 
 Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums, which they'll need to use at kickstart. Please check you can login and create competitors before kickstart, and let us know if you have any problems.
 
-Lastly, we will be [livestreaming the kickstart presentation](https://www.youtube.com/watch?v=OHYT5iO352c) for anyone who can't make it.
+Lastly, we will be [live streaming the kickstart presentation](https://www.youtube.com/watch?v=OHYT5iO352c) for anyone who can't make it.
 
 If you have any questions, please let us know as soon as possible.
 
 We look forward to seeing you all there!
-

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -17,6 +17,8 @@ Please only attend the kickstart we're expecting you at: https://docs.google.com
 
 Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums, which they'll need to use at kickstart. Please check you can login and create competitors before kickstart, and let us know if you have any problems.
 
+Lastly, we will be [livestreaming the kickstart presentation](https://www.youtube.com/watch?v=OHYT5iO352c) for anyone who can't make it.
+
 If you have any questions, please let us know as soon as possible.
 
 We look forward to seeing you all there!

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -1,6 +1,6 @@
 ---
 to: sr2020-teams
-subject: Kit Disclaimer Forms
+subject: Kit Distribution & Kickstart details
 attachments:
   - https://drive.google.com/a/studentrobotics.org/file/d/1aCHnZ6o8DkLzHef1C2lz_iIkZkOjYP6P/view?usp=sharing
 ---

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -25,7 +25,7 @@ Last week, we sent out your login details for our account management system. Thi
 
 ## Laptops
 
-If you're attending a kickstart, please be sure to remind competitors to bring a laptop, we won't have any desktops available for you to use. 1 per team is sufficient.
+If you're attending a kickstart, please be sure to remind competitors to bring a laptop, we won't have any computers available for you to use. Please bring at least 1.
 
 ## Live Stream
 

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -25,7 +25,7 @@ Last week, we sent out your login details for our account management system. Thi
 
 ## Laptops
 
-If you're going to the Cambridge or London kickstart, don't forget to remind your team to bring laptops, we won't have desktops available for you to use. To those attending Southampton, we still highly recommend you bring them!
+If you're attending a kickstart, please be sure to remind competitors to bring a laptop, we won't have any desktops available for you to use. 1 per team is sufficient.
 
 ## Live Stream
 

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -7,7 +7,7 @@ attachments:
 
 Hi all,
 
-Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits are ready and waiting at the venue. For those who can't attend kickstart, we'll contact you shortly to confirm details of shipping your kits.
+Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits will be ready and waiting at the venue. For those who can't attend kickstart, we'll contact you shortly to confirm details of shipping your kits.
 
 Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but we're sending them over early to speed up the issuing process on the day. If you're not attending Kickstart, return your form promptly to ensure you receive your kit as soon afterwards as possible.
 

--- a/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
+++ b/SR2020/2019-10-21-kit-distribution-and-kickstart-details.md
@@ -9,6 +9,8 @@ Hi all,
 
 Kickstart is less than a week away, and we're putting the finishing touches to kickstart. If you're attending a kickstart event, your kits will be ready and waiting at the venue.
 
+## Kit Disclaimer
+
 Before we can issue a kit, you must sign a kit disclaimer form. Historically these have been signed at the event, but we're sending them over early to speed up the issuing process.
 
 If you're not attending Kickstart, return your form promptly to ensure you receive your kit as soon afterwards as possible. We'll contact you shortly to confirm details for shipping your kits to you.
@@ -17,9 +19,17 @@ Attached to this email is the disclaimer form. Please read it, print it, sign it
 
 Please only attend the kickstart we're expecting you at: https://docs.google.com/spreadsheets/d/1plZqwcO0WIdoWhiUNdGxy-6uLSoH8vIsFdKzwHXtf0c/edit?usp=sharing. If you can no longer attend, please let us know.
 
+## Login Details
+
 Last week, we sent out your login details for our account management system. This will enable you to add competitors to give them access to the IDE and forums, which they'll need to use at kickstart. Please check you can login and create competitors before kickstart, and let us know if you have any problems.
 
-Lastly, we will be [live streaming the kickstart presentation](https://www.youtube.com/watch?v=OHYT5iO352c) for anyone who can't make it.
+## Laptops
+
+If you're going to the Cambridge or London kickstart, don't forget to remind your team to bring laptops, we won't have desktops available for you to use. To those attending Southampton, we still highly recommend you bring them!
+
+## Live Stream
+
+For the first time, we will be [live streaming the kickstart presentation](https://www.youtube.com/watch?v=OHYT5iO352c) for those who can't make it. If you're eager to get started, this is the best way to get information about this year's competition. Be sure to send the link round to competitors, parents, fellow staff members, and anyone else who may be interested!
 
 If you have any questions, please let us know as soon as possible.
 


### PR DESCRIPTION
To speed things up at kickstart, send the disclaimer forms out beforehand so teams can sign and return them.