### PR TITLE
Add an email asking for an address confirmation

### DIFF
--- a/SR2020/2019-10-25-address-confirmation.md
+++ b/SR2020/2019-10-25-address-confirmation.md
@@ -9,11 +9,11 @@ Hello there!
 
 As you are unable to attend kickstart, we need to ship you your kit.
 
-In a previous email, we sent over a kit disclaimer form, which must be signed and returned before we can dispatch your kit. Please let us know explicitly if this address is correct, and if it's not, let us know an updated one.
+In a previous email, we sent over a kit disclaimer form, which must be signed and returned before we can dispatch your kit.
 
-Address:
+Below is the address you gave us when signing up. Please let us know explicitly if this address is correct, and if it's not, let us know an updated one. The address should be of your school / institution, rather than your home address.
 
-$ADDRESS
+    $ADDRESS
 
 Once we have the kit disclaimer form, and a confirmation of the address to send it to, we can dispatch your kit to you.
 

--- a/SR2020/2019-10-25-address-confirmation.md
+++ b/SR2020/2019-10-25-address-confirmation.md
@@ -1,0 +1,20 @@
+---
+to: Student Robotics 2020, didn't attend kickstart
+subject: Confirming your address
+attachments:
+  - https://drive.google.com/a/studentrobotics.org/file/d/1aCHnZ6o8DkLzHef1C2lz_iIkZkOjYP6P/view?usp=sharing
+---
+
+Hello there!
+
+As you are unable to attend kickstart, we need to ship you your kit.
+
+In a previous email, we sent over a kit disclaimer form, which must be signed and returned before we can dispatch your kit. Please let us know explicitly if this address is correct, and if it's not, let us know an updated one.
+
+Address:
+
+$ADDRESS
+
+Once we have the kit disclaimer form, and a confirmation of the address to send it to, we can dispatch your kit to you.
+
+If you have any other questions, please let us know!


### PR DESCRIPTION
Before we send out kits to teams, we need to explicitly confirm their address, and ensure they sign the disclaimer form.

This email should be sent out shortly after #30.