### PR TITLE
Add email reminding about disclaimer form / address

### DIFF
--- a/SR2020/2019-11-04-kit-shipping.md
+++ b/SR2020/2019-11-04-kit-shipping.md
@@ -1,0 +1,22 @@
+---
+to: Teams who need to send disclaimer / address
+subject: Kit Shipping
+attachments:
+  - https://drive.google.com/a/studentrobotics.org/file/d/1aCHnZ6o8DkLzHef1C2lz_iIkZkOjYP6P/view?usp=sharing
+---
+
+Hello there!
+
+If you're reading this, it's because you were unable to attend kickstart.
+
+As you're likely aware, our kickstart event has now happened, and the game for SR2020 has been announced: [Two Colours](https://studentrobotics.org/docs/rules/)
+
+## Kit Disclaimer
+
+Before we can dispatch your kit, we need you to sign a Kit Disclaimer form, attached to this email. Please read it, print it, sign it, and [send it back to us](mailto:teams@studentrobotics.org).
+
+## Address confirmation
+
+We need an explicit confirmation of the address to send the kit to, to ensure it gets sent to the right place.
+
+Once we've got the required information, we'll get your kit dispatched, and let you know once it's on its way.


### PR DESCRIPTION
We need to remind teams to send in disclaimers / confirm addresses.

The 2 sections of the email (Kit Disclaimer and Address confirmation) will be removed for each recipient depending on what they need to send. There wasn't a nice way to wording around it, so i'll have to send it manually.