### PR TITLE
Add tech days, mentoring and competition-date-input email

### DIFF
--- a/SR2020/2019-11-11-tech-days-and-mentoring.md
+++ b/SR2020/2019-11-11-tech-days-and-mentoring.md
@@ -10,10 +10,9 @@ teams build the best robots they can.
 
 ### Tech Days
 
-Tech Days are opportunities for teams to get help if they’re struggling with a
-technical issue, and a controlled environment for students to make more progress
-on their robots. They’re also an opportunity to see how well they’re doing in
-comparison to other teams.
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They’re also an opportunity to see how other
+teams are doing or get more direct help with your robots.
 
 We will provide a space for you to work in, with power and internet access, as
 well as volunteers able to help you with your kits and hands-on guidance with

--- a/SR2020/2019-11-11-tech-days-and-mentoring.md
+++ b/SR2020/2019-11-11-tech-days-and-mentoring.md
@@ -53,7 +53,7 @@ sadly can’t guarantee every team gets a mentor.
 
 ### Competition Planning
 
-We're currently evaluating venues for the SR2020 competition event and would
+We’re currently evaluating venues for the SR2020 competition event and would
 like your input on which dates would be best for your team. Please complete this
 Doodle poll to tell us which weekends you expect that your team would be able to
 attend.

--- a/SR2020/2019-11-11-tech-days-and-mentoring.md
+++ b/SR2020/2019-11-11-tech-days-and-mentoring.md
@@ -1,0 +1,69 @@
+---
+to: sr2020-teams
+subject: Tech Days, Mentoring and input on Competition Dates
+---
+
+Hello,
+
+With the competition now well underway, we’re planning the ways we can help your
+teams build the best robots they can.
+
+### Tech Days
+
+Tech Days are opportunities for teams to get help if they’re struggling with a
+technical issue, and a controlled environment for students to make more progress
+on their robots. They’re also an opportunity to see how well they’re doing in
+comparison to other teams.
+
+We will provide a space for you to work in, with power and internet access, as
+well as volunteers able to help you with your kits and hands-on guidance with
+your robots.
+
+The next Tech Day is in [London, on Saturday 30th November][london-tech-day],
+though will only take place if we have sufficient interest. If you’d like to
+attend, please **[sign up for the London Tech Day][tech-day-signup]** by
+Wednesday 27th November.
+
+We’ll be organising more Tech Days soon, so keep an eye on the website.
+
+### Mentoring
+
+We’re assembling some volunteers who are able to mentor your team.
+
+Your mentor will help guide your team towards good solutions for their robot,
+provide assistance where they might need it as well as help them understand the
+kit, the rules and the competition as a whole.
+
+Mentors are volunteers who have typically competed or helped out with the
+competition before. They’re able to give help on all aspects of building and
+programming your robot, and if they don’t know something, they typically know
+someone who does.
+
+Mentors will mostly attend in person, though for some teams we may not have
+anyone nearby. In those cases we may be able to offer remote mentoring (by video
+call).
+
+If you’d like a mentor to visit your team either regularly or as a one-off to
+help them out with building their robot, fill out this sign-up form:
+
+**[Sign up to get a mentor][mentoring-signup]**.
+
+We typically have more teams interested than we have free volunteers, so we
+sadly can’t guarantee every team gets a mentor.
+
+### Competition Planning
+
+We're currently evaluating venues for the SR2020 competition event and would
+like your input on which dates would be best for your team. Please complete this
+Doodle poll to tell us which weekends you expect that your team would be able to
+attend.
+
+**[Tell us which weekends are best for your team][competition-dates-doodle]**.
+
+-- The SR Competition Team
+
+
+[london-tech-day]: https://studentrobotics.org/events/sr2020/london-tech-day-november/
+[tech-day-signup]: https://forms.gle/vSrzt4o85542MGcv8
+[mentoring-signup]: https://forms.gle/DCNpk9zsFnA8fRXW6
+[competition-dates-doodle]: https://doodle.com/poll/rt5d2abxfscdnhr2


### PR DESCRIPTION
Fixes https://github.com/srobo/competition-team-minutes/issues/175.

Regarding the forms:
 * I'm expecting that the mentoring form will allow teams to sign up and then we'll assign them a mentor
 * I'm expecting that the Tech Day form will allow teams to sign up for specific Tech Days and that we'll re-use it for the rest of the SR2020 Tech Days (just altering the options for the first question)

If we're happy with this, I'm tempted to also turn it into a blog post for the website (minus the competition doodle).