### PR TITLE
Add kit shipment update email

### DIFF
--- a/SR2020/2019-11-25-kit-shipment-update.md
+++ b/SR2020/2019-11-25-kit-shipment-update.md
@@ -7,6 +7,6 @@ Hello!
 
 Unfortunately, We are currently facing delays getting your kit shipped out to you. An issue exists around ensuring the batteries adhere to new legislation around transporting dangerous good (of which our batteries are).
 
-Please be assured we're actively working on this, and will let you know as there's an update. We have also taken steps to ensure this delay doesn't happen in future.
+Please be assured we're actively working on this, and will let you know as there's an update. We will be steps to ensure this delay doesn't happen in future.
 
 Thank you for your patience.

--- a/SR2020/2019-11-25-kit-shipment-update.md
+++ b/SR2020/2019-11-25-kit-shipment-update.md
@@ -5,8 +5,8 @@ subject: Kit Shipment update
 
 Hello!
 
-Unfortunately, We are currently facing delays getting your kit shipped out to you. An issue exists around ensuring the batteries adhere to new legislation around transporting dangerous good (of which our batteries are).
+Unfortunately, we are currently facing delays getting your kit shipped out to you. An issue exists around ensuring the batteries adhere to new legislation around transporting dangerous goods (of which our batteries are).
 
-Please be assured we're actively working on this, and will let you know as there's an update. We will be steps to ensure this delay doesn't happen in future.
+Please be assured we're actively working on this, and will let you know as there's an update. We will be taking steps to ensure this delay doesn't happen in future.
 
 Thank you for your patience.

--- a/SR2020/2019-11-25-kit-shipment-update.md
+++ b/SR2020/2019-11-25-kit-shipment-update.md
@@ -1,0 +1,12 @@
+---
+to: Those who are awaiting
+subject: Kit Shipment update
+---
+
+Hello!
+
+Unfortunately, We are currently facing delays getting your kit shipped out to you.
+
+Please be assured we're actively working on this, and will let you know as there's an update. We have also taken steps to ensure this delay doesn't happen in future.
+
+Thank you for your patience.

--- a/SR2020/2019-11-25-kit-shipment-update.md
+++ b/SR2020/2019-11-25-kit-shipment-update.md
@@ -5,7 +5,7 @@ subject: Kit Shipment update
 
 Hello!
 
-Unfortunately, We are currently facing delays getting your kit shipped out to you.
+Unfortunately, We are currently facing delays getting your kit shipped out to you. An issue exists around ensuring the batteries adhere to new legislation around transporting dangerous good (of which our batteries are).
 
 Please be assured we're actively working on this, and will let you know as there's an update. We have also taken steps to ensure this delay doesn't happen in future.
 


### PR DESCRIPTION
Fixes https://github.com/srobo/competition-team-minutes/issues/181

Add an email updating teams about the status of kits.

Unsure if it's worth talking about the specifics of _why_ there's a delay?