### PR TITLE
Add inactive team prompt email

### DIFF
--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -32,6 +32,14 @@ Mentors will mostly attend in person, though for some teams we may not have
 anyone nearby. In those cases we may be able to offer remote mentoring (by video
 call).
 
+## Tech Days
+
+Tech Days are opportunities for teams to spend a whole day working on their
+robot with lots of help available. They’re also an opportunity to see how other
+teams are doing or get more direct help with your robots.
+
+You can see the list of upcoming tec days on [our website](https://studentrobotics.org/events/).
+
 ## Unable to continue?
 
 If you no longer wish to, or are unable to compete in Student Robotics 2020, please let us know as soon as possible.

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -38,7 +38,7 @@ Tech Days are opportunities for teams to spend a whole day working on their
 robot with lots of help available. They’re also an opportunity to see how other
 teams are doing or get more direct help with your robots.
 
-You can see the list of upcoming tec days on [our website](https://studentrobotics.org/events/).
+You can see the list of upcoming tech days on [our website](https://studentrobotics.org/events/).
 
 ## Unable to continue?
 

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -1,6 +1,6 @@
 ---
 to: Teams deemed 'inactive'
-subject: Student Robotics activity
+subject: Student Robotics inactivity
 ---
 
 Hello There!

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -1,6 +1,6 @@
 ---
 to: Teams deemed 'inactive'
-subject: Lack of activity in Student Robotics
+subject: Student Robotics activity
 ---
 
 Hello There!

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -1,6 +1,6 @@
 ---
 to: Teams deemed 'inactive'
-subject: Student Robotics inactivity
+subject: We haven't seen you in a while
 ---
 
 Hello There!

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -5,7 +5,7 @@ subject: Lack of activity in Student Robotics
 
 Hello There!
 
-Our records show you've not been especially active on the IDE or Forum recently, and we want to offer our support!
+Our records show you've not been especially active on the IDE recently, and we want to offer our support!
 
 ## Assistance
 

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -1,6 +1,6 @@
 ---
 to: Teams deemed 'inactive'
-subject: Southampton Tech Day 8th Feb
+subject: Lack of activity in Student Robotics
 ---
 
 Hello There!

--- a/SR2020/2020-02-19-inactive-team-prompt.md
+++ b/SR2020/2020-02-19-inactive-team-prompt.md
@@ -1,0 +1,41 @@
+---
+to: Teams deemed 'inactive'
+subject: Southampton Tech Day 8th Feb
+---
+
+Hello There!
+
+Our records show you've not been especially active on the IDE or Forum recently, and we want to offer our support!
+
+## Assistance
+
+If you're struggling with your robot, here's a few resources which might help you out:
+
+- [The Docs](https://studentrobotics.org/docs/)
+- [The Forum](https://studentrobotics.org/forum/), to get help from other teams / blue shirts
+- [Our Twitter](https://twitter.com/studentrobotics), where you can see what other teams are up to
+
+## Mentors
+
+Alternatively, if you'd prefer some more hands-on support, let us know and we may be able to allocate you a mentor.
+
+Your mentor will help guide your team towards good solutions for their robot,
+provide assistance where they might need it as well as help them understand the
+kit, the rules and the competition as a whole.
+
+Mentors are volunteers who have typically competed or helped out with the
+competition before. They’re able to give help on all aspects of building and
+programming your robot, and if they don’t know something, they typically know
+someone who does.
+
+Mentors will mostly attend in person, though for some teams we may not have
+anyone nearby. In those cases we may be able to offer remote mentoring (by video
+call).
+
+## Unable to continue?
+
+If you no longer wish to, or are unable to compete in Student Robotics 2020, please let us know as soon as possible.
+
+If you have any further questions, please let us know!
+
+-- SR Competition Team


### PR DESCRIPTION
Add a prompt to teams which are considered inactive (definition undefined), and offer them some help.

Yet to work out what 'inactive' means specifically (will be based on IDE / Forum activity and number of competitor accounts), so the wording might change slightly once we've found numbers.