### PR TITLE
Add email pointing to new website page about COVID-19

### DIFF
--- a/SR2020/2020-03-06-covid-19-website.md
+++ b/SR2020/2020-03-06-covid-19-website.md
@@ -9,7 +9,7 @@ Hello again,
 
 Following on from an email sent yesterday, we have now put a page on our website expanding further on how we're assessing the situation regarding COVID-19.
 
-You can find it here: https://studentrobotics.org/news/2020-03-11-sr2020-covid-19-updates/
+You can find it here: https://studentrobotics.org/covid-19/
 
 We will be keeping this page up to date as things progress. As it stands the competition is going ahead as planned, however should this change, we will let you know immediately.
 

--- a/SR2020/2020-03-06-covid-19-website.md
+++ b/SR2020/2020-03-06-covid-19-website.md
@@ -11,6 +11,6 @@ Following on from an email sent yesterday, we have now put a page on our website
 
 You can find it here: https://studentrobotics.org/news/2020-03-11-sr2020-covid-19-updates/
 
-We will be keeping this page up to date as things progress. Should the event be cancelled, we will of course let you know immediately.
+We will be keeping this page up to date as things progress. As it stands the competition is going ahead as planned, however should this change, we will let you know immediately.
 
 If you or your school has any questions about our handling of the event, please don't hesitate to contact us at teams@studentrobotics.org.

--- a/SR2020/2020-03-06-covid-19-website.md
+++ b/SR2020/2020-03-06-covid-19-website.md
@@ -1,0 +1,16 @@
+---
+to: sr2020-teams
+subject: COVID-19 Coronavirus Student Robotics Updates
+---
+
+# COVID-19 Coronavirus Student Robotics Updates
+
+Hello again,
+
+Following on from an email sent yesterday, we have now put a page on our website expanding further on how we're assessing the situation regarding COVID-19.
+
+You can find it here: https://studentrobotics.org/news/2020-03-11-sr2020-covid-19-updates/
+
+We will be keeping this page up to date as things progress. Should the event be cancelled, we will of course let you know immediately.
+
+If you or your school has any questions about our handling of the event, please don't hesitate to contact us at teams@studentrobotics.org.


### PR DESCRIPTION
Add an email pointing teams to https://github.com/srobo/website/pull/197.

It's unfortunate the last email was sent so recently, but I think it's important we point teams to the website for full updates.