### PR TITLE
Add email announcing new date and possible virtual competition

### DIFF
--- a/SR2020/2020-04-09-competition-date-update.md
+++ b/SR2020/2020-04-09-competition-date-update.md
@@ -1,0 +1,22 @@
+---
+to: sr2020-teams
+subject: Student Robotics 2020 Update
+---
+
+Hi all,
+
+After surveying our SR2020 teams and volunteers, we have selected the **weekend of the 4th July 2020** to be the most appropriate date for the competition.
+
+The COVID-19 situation changes often, so we will re-evaluate in mid-May. At this time we'll evaluate the viability of running a competition.
+
+## Virtual Competition
+
+We are also considering a virtual competition, and are exploring possibilities of how this could work. This virtual competition would likely be held over a few weeks around late May / early June. We aim to keep the virtual competition rules as similar to Two Colours as possible. This is to ensure that teams can use the code they have been working on since Kickstart.
+
+You can still find the latest updates on our [COVID-19 updates page](https://studentrobotics.org/covid-19/).
+
+## Working on your robot
+
+We hope you're still working on your robots as much as possible. The IDEs will remain open and staffed for the foreseeable future should you need help from us blueshirts.
+
+If you have any further questions, please don't hesitate to [get in touch](teams@studentrobotics.org)!

--- a/SR2020/2020-04-09-competition-date-update.md
+++ b/SR2020/2020-04-09-competition-date-update.md
@@ -17,6 +17,6 @@ You can still find the latest updates on our [COVID-19 updates page](https://stu
 
 ## Working on your robot
 
-We hope you're still working on your robots as much as possible. The IDEs will remain open and staffed for the foreseeable future should you need help from us blueshirts.
+We hope you're still working on your robots as much as possible. The [IDE](https://studentrobotics.org/ide/) and [forum](https://studentrobotics.org/forum/) will remain open and staffed for the foreseeable future should you need help from us blueshirts.
 
 If you have any further questions, please don't hesitate to [get in touch](teams@studentrobotics.org)!


### PR DESCRIPTION
Closely resembles https://studentrobotics.org/news/2020-03-28-sr2020-new-provisional-date/