### PR TITLE
Add email about moving competitors betwen teams

### DIFF
--- a/SR2021/2020-12-08-team-split.md
+++ b/SR2021/2020-12-08-team-split.md
@@ -11,7 +11,7 @@ If you'd like to move a competitor between teams:
 
 If they **are** on Discord already, you'll need to send us their username, and which team you want them to be in, and we can transfer them over.
 
-If they **aren't** on Discord, then yes simply giving them the password for the corresponding team will add them to the correct one on registration.
+If they **aren't** on Discord, then simply giving them the password for the corresponding team will add them to the correct one upon registration.
 
 If you would like more or fewer teams, please just let us know.
 

--- a/SR2021/2020-12-08-team-split.md
+++ b/SR2021/2020-12-08-team-split.md
@@ -1,0 +1,20 @@
+---
+to: Team Leaders who requested multiple teams
+subject: Student Robotics Discord Details
+---
+
+Hello there.
+
+We notice that whilst you've requested multiple teams for this year's competition, most of your competitors are in a single team.
+
+If you'd like to move a competitor between teams:
+
+If they **are** on Discord already, you'll need to send us their username, and which team you want them to be in, and we can transfer them over.
+
+If they **aren't** on Discord, then yes simply giving them the password for the corresponding team will add them to the correct one on registration.
+
+If you would like more or fewer teams, please just let us know.
+
+Something also to note: Just because teams are from the same school / institution, doesn't make them any less rivals. Teams should be encouraged to work separately, and should be considered entirely isolated. It's for the same reason that competitors must only be in a single team, should not move, and should only actively contribute to a single teams' robot.
+
+If you have any questions, please let us know.


### PR DESCRIPTION
As discussed in https://github.com/srobo/competition-team-minutes/pull/247.

We should prompt teams to properly allocate teams on Discord, and are aware of the strict separation they should have.