### PR TITLE
Add email checking teams are still wanted

### DIFF
--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -7,7 +7,7 @@ Hi,
 
 If you're reading this email, it means you have at least 1 team from your institution who seem inactive on Discord, or who have few members.
 
-If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all trying to help.
+If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all available to help.
 
 If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it with an existing one becomes more unfair the further into the competition we get.
 

--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -7,7 +7,7 @@ Hi,
 
 We noticed that one or more of your teams doesn't seem active on Discord, or has very few members. We want to ensure that every team has the opportunity to shine and gets the support they need.
 
-If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all available to help. Whilst most of the discussions and support will be happening here, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.
+If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgeable volunteers, competitors and team leaders, all available to help. Whilst most of the discussions and support will be happening here, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.
 
 If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it with an existing one becomes more unfair the further into the competition we get.
 

--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -9,7 +9,7 @@ If you're reading this email, it means you have at least 1 team from your instit
 
 If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all trying to help.
 
-If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it and merging it with an existing one becomes more unfair the further into the competition we get.
+If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it with an existing one becomes more unfair the further into the competition we get.
 
 If we are worrying unnecessarily, please let us know to put our minds at ease!
 

--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -5,7 +5,7 @@ subject: Student Robotics Teams
 
 Hi,
 
-If you're reading this email, it means you have at least 1 team from your institution who seem inactive on Discord, or who have few members.
+We noticed that one or more of your teams doesn't seem active on Discord, or has very few members. We want to ensure that every team has the opportunity to shine and gets the support they need.
 
 If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all available to help. Whilst most of the discussions and support will be happening here, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.
 

--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -7,7 +7,7 @@ Hi,
 
 If you're reading this email, it means you have at least 1 team from your institution who seem inactive on Discord, or who have few members.
 
-If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all available to help.
+If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all available to help. Whilst most of the discussions and support will be happening here, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.
 
 If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it with an existing one becomes more unfair the further into the competition we get.
 

--- a/SR2021/2021-01-12-team-numbers.md
+++ b/SR2021/2021-01-12-team-numbers.md
@@ -1,0 +1,16 @@
+---
+to: SR2021 institutions with inactive teams
+subject: Student Robotics Teams
+---
+
+Hi,
+
+If you're reading this email, it means you have at least 1 team from your institution who seem inactive on Discord, or who have few members.
+
+If you have teams requiring further guidance and support, the Discord is the best place to get support. Filled with knowledgable volunteers, competitors and team leaders, all trying to help.
+
+If you no longer wish to have as many teams as you registered for, please let us know. Dropping out a team and merging it and merging it with an existing one becomes more unfair the further into the competition we get.
+
+If we are worrying unnecessarily, please let us know to put our minds at ease!
+
+We look forward to seeing you all at our [first league session](https://studentrobotics.org/events/sr2021/league-1/) this weekend!


### PR DESCRIPTION
Add an email checking institutions still want the same number of teams they started off with.

This covers both institutions with 1 team which is inactive, _and_ those with multiple teams where one / many are inactive.