### PR TITLE
Add email variants offering mentoring to all teams

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -16,6 +16,7 @@ COVID-19
 Holles
 blueshirt
 blueshirts
+P.S
 YouTube
 livestream
 18l

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -30,5 +30,14 @@ team or you just need a fresh pair of eyes on something. Our volunteers have a
 wealth of experience from both competing in Student Robotics and helping lots of
 teams, so there's a good chance they can help :)
 
+Finally, we'd like to confirm the details for the friendlies ahead of the next
+round of league matches. The friendlies will be streamed from noon (UK time) on
+Saturday 13th March with code submission at 8pm on Friday 12th. If you'd like to
+take part please send us a message in [#friendly-matches][friendly-matches].
+We'd love to see lots of teams there as it's a great opportunity to find and fix
+any last minute bugs before the league session.
+
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
+
+[friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -38,6 +38,8 @@ take part please send us a message in [#friendly-matches][friendly-matches].
 We'd love to see lots of teams there as it's a great opportunity to find and fix
 any last minute bugs before the league session.
 
+— The SR Competition Team
+
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
 

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -18,8 +18,8 @@ in the form of a regular mentor. This would be a volunteer who is able to be
 around whenever you regularly meet and would get to know your team and your
 robot. Whatever platform you use (whether it's Discord or something else),
 they'd be able to join your meetings to help you out. (For safeguarding reasons
-we need your team leader to also be in any video calls; your team leader will
-have details about this).
+we need you or another adult responsible for the team to also be in any video
+calls).
 
 If you're interested in having a regular mentor please just reply to this
 email, letting us know when you meet and what platform you use.

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -7,9 +7,11 @@ Hi,
 
 It was great to see your robot at the second league session. We hope you found
 it as exciting as we did and are looking forward to the new challenges which
-module Ⅲ brings. The [full rulebook][rulebook] and [simulator][simulator]
-updates are available on our website, so do check them out if you haven't
-already!
+module Ⅲ brings. The full rulebook and simulator updates are available on our
+website, so do check them out if you haven't already!
+
+    https://studentrobotics.org/docs/rules/
+    https://studentrobotics.org/docs/simulator/
 
 We also wanted to check on how you're doing and whether there's any more help
 you need?
@@ -34,7 +36,10 @@ teams, so there's a good chance they can help :)
 Finally, we'd like to confirm the details for the friendlies ahead of the next
 round of league matches. The friendlies will be streamed from noon (UK time) on
 Saturday 13th March with code submission at 8pm on Friday 12th. If you'd like to
-take part please send us a message in [#friendly-matches][friendly-matches].
+take part please send us a message in #friendly-matches:
+
+    https://discord.com/channels/775497131057741836/780326509738852402
+
 We'd love to see lots of teams there as it's a great opportunity to find and fix
 any last minute bugs before the league session.
 
@@ -42,7 +47,3 @@ any last minute bugs before the league session.
 
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
-
-[rulebook]: https://studentrobotics.org/docs/rules/
-[simulator]: https://studentrobotics.org/docs/simulator/
-[friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -7,8 +7,9 @@ Hi,
 
 It was great to see your robot at the second league session. We hope you found
 it as exciting as we did and are looking forward to the new challenges which
-module Ⅲ brings. The full rulebook and simulator updates are available on our
-website, so do check them out if you haven't already!
+module Ⅲ brings. The [full rulebook][rulebook] and [simulator][simulator]
+updates are available on our website, so do check them out if you haven't
+already!
 
 We also wanted to check on how you're doing and whether there's any more help
 you need?
@@ -40,4 +41,6 @@ any last minute bugs before the league session.
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
 
+[rulebook]: https://studentrobotics.org/docs/rules/
+[simulator]: https://studentrobotics.org/docs/simulator/
 [friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup-inactive.md
+++ b/SR2021/2021-02-14-league-2-followup-inactive.md
@@ -1,0 +1,34 @@
+---
+to: Teams who attended the leagues but aren't very active
+subject: Would you like a mentor?
+---
+
+Hi,
+
+It was great to see your robot at the second league session. We hope you found
+it as exciting as we did and are looking forward to the new challenges which
+module Ⅲ brings. The full rulebook and simulator updates are available on our
+website, so do check them out if you haven't already!
+
+We also wanted to check on how you're doing and whether there's any more help
+you need?
+
+In addition to Discord, we'd also like to offer you some more hands-on support
+in the form of a regular mentor. This would be a volunteer who is able to be
+around whenever you regularly meet and would get to know your team and your
+robot. Whatever platform you use (whether it's Discord or something else),
+they'd be able to join your meetings to help you out. (For safeguarding reasons
+we need your team leader to also be in any video calls; your team leader will
+have details about this).
+
+If you're interested in having a regular mentor please just reply to this
+email, letting us know when you meet and what platform you use.
+
+Otherwise, there's usually lots of volunteers around in Discord to help out
+if you need anything. Whether it's help programming your robot, organising your
+team or you just need a fresh pair of eyes on something. Our volunteers have a
+wealth of experience from both competing in Student Robotics and helping lots of
+teams, so there's a good chance they can help :)
+
+P.S: We've found that teams who meet regularly tend to do better, so if your
+team doesn't have a regular meeting time you might find it helps to set one up.

--- a/SR2021/2021-02-14-league-2-followup-no-shows.md
+++ b/SR2021/2021-02-14-league-2-followup-no-shows.md
@@ -27,5 +27,10 @@ responsible for the team to also be in any video calls).
 If you're interested in having a regular mentor please just reply to this
 email, letting us know when you meet and what platform you use.
 
+{% if inactive %}
+Alternatively, if your team will no longer be competing in Student Robotics
+please let us know so we can remove you from this year's mailing lists.
+{% endif %}
+
 P.S: if you don't have a regular meeting time, that's fine too. We have found
 that teams who meet regularly tend to do better though!

--- a/SR2021/2021-02-14-league-2-followup-no-shows.md
+++ b/SR2021/2021-02-14-league-2-followup-no-shows.md
@@ -1,0 +1,31 @@
+---
+to: Teams who didn't attend the leagues
+subject:
+    - Still interested in Student Robotics 2021?  # if they appear inactive
+    - Would you like a mentor?  # if they appear active
+---
+
+Hi,
+
+We noticed your team didn't make it to the recent league sessions. We wanted to
+reach out to see if there was any more support we could provide you, or questions
+we could answer?
+
+There's usually lots of volunteers around in Discord to help out if you need
+anything, whether it's help programming your robot, organising your team or you
+just need a fresh pair of eyes on something. Our volunteers have a wealth of
+experience from both competing in Student Robotics and helping lots of teams, so
+there's a good chance they can help :)
+
+We'd also like to offer you some more hands-on support in the form of a regular
+mentor. This would be a volunteer who is able to be around whenever you
+regularly meet and would get to know your team and your robot. Whatever platform
+you use (whether it's Discord or something else), they'd be able to join your
+meetings to help you out. (For safeguarding reasons we need your team leader to
+also be in any video calls; your team leader will have details about this).
+
+If you're interested in having a regular mentor please just reply to this
+email, letting us know when you meet and what platform you use.
+
+P.S: if you don't have a regular meeting time, that's fine too. We have found
+that teams who meet regularly tend to do better though!

--- a/SR2021/2021-02-14-league-2-followup-no-shows.md
+++ b/SR2021/2021-02-14-league-2-followup-no-shows.md
@@ -32,5 +32,14 @@ Alternatively, if your team will no longer be competing in Student Robotics
 please let us know so we can remove you from this year's mailing lists.
 {% endif %}
 
+Finally, we'd like to confirm the details for the friendlies ahead of the next
+round of league matches. The friendlies will be streamed from noon (UK time) on
+Saturday 13th March with code submission at 8pm on Friday 12th. If you'd like to
+take part please send us a message in [#friendly-matches][friendly-matches].
+We'd love to see lots of teams there as it's a great opportunity to find and fix
+any last minute bugs before the league session.
+
 P.S: if you don't have a regular meeting time, that's fine too. We have found
 that teams who meet regularly tend to do better though!
+
+[friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup-no-shows.md
+++ b/SR2021/2021-02-14-league-2-followup-no-shows.md
@@ -21,8 +21,8 @@ We'd also like to offer you some more hands-on support in the form of a regular
 mentor. This would be a volunteer who is able to be around whenever you
 regularly meet and would get to know your team and your robot. Whatever platform
 you use (whether it's Discord or something else), they'd be able to join your
-meetings to help you out. (For safeguarding reasons we need your team leader to
-also be in any video calls; your team leader will have details about this).
+meetings to help you out. (For safeguarding reasons we need you or another adult
+responsible for the team to also be in any video calls).
 
 If you're interested in having a regular mentor please just reply to this
 email, letting us know when you meet and what platform you use.

--- a/SR2021/2021-02-14-league-2-followup-no-shows.md
+++ b/SR2021/2021-02-14-league-2-followup-no-shows.md
@@ -39,6 +39,8 @@ take part please send us a message in [#friendly-matches][friendly-matches].
 We'd love to see lots of teams there as it's a great opportunity to find and fix
 any last minute bugs before the league session.
 
+— The SR Competition Team
+
 P.S: if you don't have a regular meeting time, that's fine too. We have found
 that teams who meet regularly tend to do better though!
 

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -38,6 +38,8 @@ take part please send us a message in [#friendly-matches][friendly-matches].
 We'd love to see lots of teams there as it's a great opportunity to find and fix
 any last minute bugs before the league session.
 
+— The SR Competition Team
+
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
 

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -1,5 +1,5 @@
 ---
-to: Teams who attended the leagues but aren't very active
+to: Teams who attended the leagues and are active
 subject: Preparing for league 3
 ---
 

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -7,8 +7,9 @@ Hi,
 
 It was great to see your robot at the second league session. We hope you found
 it as exciting as we did and are looking forward to the new challenges which
-module Ⅲ brings. The full rulebook and simulator updates are available on our
-website, so do check them out if you haven't already!
+module Ⅲ brings. The [full rulebook][rulebook] and [simulator][simulator]
+updates are available on our website, so do check them out if you haven't
+already!
 
 We just wanted to check on how you're doing and whether there's any more help
 you need?
@@ -40,4 +41,6 @@ any last minute bugs before the league session.
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
 
+[rulebook]: https://studentrobotics.org/docs/rules/
+[simulator]: https://studentrobotics.org/docs/simulator/
 [friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -30,5 +30,14 @@ team to also be in any video calls).
 If you're interested in having a regular mentor please just reply to this
 email, letting us know when you meet and what platform you use.
 
+Finally, we'd like to confirm the details for the friendlies ahead of the next
+round of league matches. The friendlies will be streamed from noon (UK time) on
+Saturday 13th March with code submission at 8pm on Friday 12th. If you'd like to
+take part please send us a message in [#friendly-matches][friendly-matches].
+We'd love to see lots of teams there as it's a great opportunity to find and fix
+any last minute bugs before the league session.
+
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
+
+[friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -24,8 +24,8 @@ mentor your team. This would provide you some more hands-on support in the form
 of a volunteer who is able to be around whenever you regularly meet and would
 get to know your team and your robot. Whatever platform you use (whether it's
 Discord or something else), they'd be able to join your meetings to help you
-out. (For safeguarding reasons we need your team leader to also be in any video
-calls; your team leader will have details about this).
+out. (For safeguarding reasons we need you or another adult responsible for the
+team to also be in any video calls).
 
 If you're interested in having a regular mentor please just reply to this
 email, letting us know when you meet and what platform you use.

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -1,0 +1,34 @@
+---
+to: Teams who attended the leagues but aren't very active
+subject: Preparing for league 3
+---
+
+Hi,
+
+It was great to see your robot at the second league session. We hope you found
+it as exciting as we did and are looking forward to the new challenges which
+module Ⅲ brings. The full rulebook and simulator updates are available on our
+website, so do check them out if you haven't already!
+
+We just wanted to check on how you're doing and whether there's any more help
+you need?
+
+As a reminder, there's usually lots of volunteers around in Discord to help out
+if you need anything, whether it's help programming your robot, organising your
+team or you just need a fresh pair of eyes on something. Our volunteers have a
+wealth of experience from both competing in Student Robotics and helping lots of
+teams, so there's a good chance they can help :)
+
+We also have a limited number of volunteers who would be able to regularly
+mentor your team. This would provide you some more hands-on support in the form
+of a volunteer who is able to be around whenever you regularly meet and would
+get to know your team and your robot. Whatever platform you use (whether it's
+Discord or something else), they'd be able to join your meetings to help you
+out. (For safeguarding reasons we need your team leader to also be in any video
+calls; your team leader will have details about this).
+
+If you're interested in having a regular mentor please just reply to this
+email, letting us know when you meet and what platform you use.
+
+P.S: We've found that teams who meet regularly tend to do better, so if your
+team doesn't have a regular meeting time you might find it helps to set one up.

--- a/SR2021/2021-02-14-league-2-followup.md
+++ b/SR2021/2021-02-14-league-2-followup.md
@@ -7,9 +7,11 @@ Hi,
 
 It was great to see your robot at the second league session. We hope you found
 it as exciting as we did and are looking forward to the new challenges which
-module Ⅲ brings. The [full rulebook][rulebook] and [simulator][simulator]
-updates are available on our website, so do check them out if you haven't
-already!
+module Ⅲ brings. The full rulebook and simulator updates are available on our
+website, so do check them out if you haven't already!
+
+    https://studentrobotics.org/docs/rules/
+    https://studentrobotics.org/docs/simulator/
 
 We just wanted to check on how you're doing and whether there's any more help
 you need?
@@ -34,7 +36,10 @@ email, letting us know when you meet and what platform you use.
 Finally, we'd like to confirm the details for the friendlies ahead of the next
 round of league matches. The friendlies will be streamed from noon (UK time) on
 Saturday 13th March with code submission at 8pm on Friday 12th. If you'd like to
-take part please send us a message in [#friendly-matches][friendly-matches].
+take part please send us a message in #friendly-matches:
+
+    https://discord.com/channels/775497131057741836/780326509738852402
+
 We'd love to see lots of teams there as it's a great opportunity to find and fix
 any last minute bugs before the league session.
 
@@ -42,7 +47,3 @@ any last minute bugs before the league session.
 
 P.S: We've found that teams who meet regularly tend to do better, so if your
 team doesn't have a regular meeting time you might find it helps to set one up.
-
-[rulebook]: https://studentrobotics.org/docs/rules/
-[simulator]: https://studentrobotics.org/docs/simulator/
-[friendly-matches]: https://discord.com/channels/775497131057741836/780326509738852402


### PR DESCRIPTION
These are all intended to go out at the same time, however they adapt the message a bit to the recipients. This aims to encourage the less active teams to get a mentor more than the more active ones, while ensuring that everyone is aware that mentoring is available.

As such, these are largely a copy/paste of the messages sent in Discord (see https://github.com/srobo/team-emails/pull/76), with light adaptation for being sent by email to the team-leaders rather than direct to the teams.

This also includes brief messaging about the rules/simulator updates being available, though that isn't the focus of these emails.

Fixes https://github.com/srobo/tasks/issues/646
Fixes https://github.com/srobo/tasks/issues/647