### PR TITLE
Add email to chase teams who we still haven't heard from

### DIFF
--- a/SR2022/2022-03-03-status-update-silent-teams.md
+++ b/SR2022/2022-03-03-status-update-silent-teams.md
@@ -1,0 +1,20 @@
+---
+to: Student Robotics 2022 teams we haven't heard from in a while (chase 1)
+subject: Let us know how your robot is progressing
+---
+
+Hi {team-supervisor-name},
+
+We haven't heard from your team in a while and wanted to check how you're doing?
+
+If you're struggling with your robot, or if you're just keeping your strategy
+secret (we promise we won't tell anyone) we'd love to know how we can best
+support your team.
+
+We're in the process of planning for the competition and will soon need to know
+how many competitors you will be bringing.
+
+Could you please give a quick status update on how you're doing?
+
+Thanks,
+-- the Competition Team


### PR DESCRIPTION
This should go out as soon as possible, to chase teams who we're concerned aren't making any progress.