### PR TITLE
Add email to again chase teams who we still haven't heard from

### DIFF
--- a/SR2022/2022-03-09-status-update-still-silent-teams.md
+++ b/SR2022/2022-03-09-status-update-still-silent-teams.md
@@ -1,0 +1,20 @@
+---
+to: Student Robotics 2022 teams we haven't heard from in a while (chase 2)
+subject: Let us know how your robot is progressing
+---
+
+Hi {team-supervisor-name},
+
+We haven't heard from your team in a while and wanted to check how you're doing?
+
+If you're struggling with your robot, or if you're just keeping your strategy
+secret (we promise we won't tell anyone) we'd love to know how we can best
+support your team.
+
+Alternatively if your team are dropping out, please let us know and we'll be in
+touch with details of how to return the kit.
+
+Could you please give a quick status update on how you're doing?
+
+Thanks,
+-- the Competition Team


### PR DESCRIPTION
This aims to be sent out a week or so after #103, to the teams who we still haven't heard from after that email goes out.

cc @srobo/kit-committee as this email touches on return of kits (albeit more as a way to prod the team supervisor into action).