### PR TITLE
Add email for extra details from potential teams

### DIFF
--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -13,7 +13,7 @@ Thank you for your interest in Student Robotics 2023. We would like to offer you
    1. Name
    2. Email address
    3. Contact phone number
-4. Are you able to attend a physical competition in the UK in early April?
+4. Are you able to attend a physical competition in the UK on a weekend in early April?
 
 Once we have these details, we can confirm your place, and then you're in!
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -5,9 +5,7 @@ subject: Confirming your details for SR2023
 
 Hello!
 
-Thank you for your interest in Student Robotics 2023.
-
-Before we can confirm your place, we have a few questions and extra pieces of information we need.
+Thank you for your interest in Student Robotics 2023. We would like to offer you a place. In order to do that, we have a few questions and extra pieces of information we need.
 
 1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
 2. Could you provide a second set of contact details for someone at your institution. They should know about the competition, and can be used as a backup contact.

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -11,7 +11,7 @@ Please complete the following short form: https://forms.gle/TDhCmRpvhJHR4gWP9
 
 Once we have these details, we can confirm your place, and then you're in! We will also send you a disclaimer form for the use of our kits. These will need to be signed and returned before we can give you your robot's kit.
 
-While the details for kickstart are not yet available, the events are expected to take place on the same weekend in late October. We'll let you know as soon as those are available.
+While the details for kickstart are not yet available, the events will provisionally be on the 22nd October and be in London and Southampton. We'll let you know as soon as those are available.
 
 Thanks,
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -9,7 +9,7 @@ Thank you for your interest in Student Robotics 2023. We would like to offer you
 
 Please complete the following short form: https://forms.gle/TDhCmRpvhJHR4gWP9
 
-Once we have these details, we can confirm your place, and then you're in!
+Once we have these details, we can confirm your place, and then you're in! We will also send you a disclaimer form for the use of our kits. These will need to be signed and returned before we can give you your robot's kit.
 
 While the details for kickstart are not yet available, the events are expected to take place on the same weekend in late October. We'll let you know as soon as those are available.
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -11,7 +11,7 @@ Please complete the following short form: https://forms.gle/TDhCmRpvhJHR4gWP9
 
 Once we have these details, we can confirm your place, and then you're in! We will also send you a disclaimer form for the use of our kits. These will need to be signed and returned before we can give you your robot's kit.
 
-While the details for kickstart are not yet available, the events will provisionally be on the 22nd October and be in London and Southampton. We'll let you know as soon as those are available.
+While the details for kickstart are not yet available, the events will provisionally be on the 22nd October in London and Southampton. We'll let you know as soon as those are available.
 
 Thanks,
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -1,0 +1,24 @@
+---
+to: SR2023 sign-ups
+subject: Confirming your details for SR2023
+---
+
+Hello!
+
+Thank you for your interest in Student Robotics 2023.
+
+Before we can confirm your place, we have a few questions and extra pieces of information we need.
+
+1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
+2. Could you provide a second set of contact details for someone at your institution. They should know about the competition, and can be used as a backup contact.
+   1. Name
+   2. Email address
+3. Are you able to attend a physical competition in the UK in early April?
+
+Once we have these details, we can confirm your place, and then you're in!
+
+We're in the process of finalising kickstart details, and we'll let you know as soon as those are available.
+
+Thanks,
+
+-- SR Competition Team

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -7,13 +7,7 @@ Hello!
 
 Thank you for your interest in Student Robotics 2023. We would like to offer you a place. In order to do that, we have a few questions and extra pieces of information we need.
 
-1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
-2. Can you provide a contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events.
-3. Could you provide a second set of contact details for someone at your institution (eg head of department). They should know about the competition, and can be used as a backup contact.
-   1. Name
-   2. Email address
-   3. Contact phone number
-4. Are you able to attend a physical competition in the UK on a weekend in early April?
+Please complete the following short form: https://forms.gle/TDhCmRpvhJHR4gWP9
 
 Once we have these details, we can confirm your place, and then you're in!
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -8,7 +8,7 @@ Hello!
 Thank you for your interest in Student Robotics 2023. We would like to offer you a place. In order to do that, we have a few questions and extra pieces of information we need.
 
 1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
-2. Can you provide a contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events
+2. Can you provide a contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events.
 3. Could you provide a second set of contact details for someone at your institution (eg head of department). They should know about the competition, and can be used as a backup contact.
    1. Name
    2. Email address

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -8,10 +8,12 @@ Hello!
 Thank you for your interest in Student Robotics 2023. We would like to offer you a place. In order to do that, we have a few questions and extra pieces of information we need.
 
 1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
-2. Could you provide a second set of contact details for someone at your institution. They should know about the competition, and can be used as a backup contact.
+2. A contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events
+3. Could you provide a second set of contact details for someone at your institution (eg head of department). They should know about the competition, and can be used as a backup contact.
    1. Name
    2. Email address
-3. Are you able to attend a physical competition in the UK in early April?
+   3. Contact phone number
+4. Are you able to attend a physical competition in the UK in early April?
 
 Once we have these details, we can confirm your place, and then you're in!
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -15,7 +15,7 @@ Thank you for your interest in Student Robotics 2023. We would like to offer you
 
 Once we have these details, we can confirm your place, and then you're in!
 
-We're in the process of finalising kickstart details, and we'll let you know as soon as those are available.
+While the details for kickstart are not yet available, the events are expected to take place on the same weekend in late October. We'll let you know as soon as those are available.
 
 Thanks,
 

--- a/SR2023/2022-09-29-confirm-team-details.md
+++ b/SR2023/2022-09-29-confirm-team-details.md
@@ -8,7 +8,7 @@ Hello!
 Thank you for your interest in Student Robotics 2023. We would like to offer you a place. In order to do that, we have a few questions and extra pieces of information we need.
 
 1. Can you confirm you are over the age of 18, and officially related to the institution you are bringing a team from (eg teacher at a school, leader at a scout group etc).
-2. A contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events
+2. Can you provide a contact phone number. We will only contact you by phone for urgent things, please ensure it is a number that you would have with you at events
 3. Could you provide a second set of contact details for someone at your institution (eg head of department). They should know about the competition, and can be used as a backup contact.
    1. Name
    2. Email address


### PR DESCRIPTION
We announced places to teams, but we haven't confirmed places yet. We did this on the basis we'd send another email to them confirming details and asking some follow-up questions - this is that email.