### PR TITLE
Add email inviting teams to the SR2023 Discord

### DIFF
--- a/SR2023/2022-10-18-discord-credentials.md
+++ b/SR2023/2022-10-18-discord-credentials.md
@@ -13,4 +13,4 @@ More information on this can be found in [the docs](https://studentrobotics.org/
 
 Additionally, we like to make sure we are aware which members are volunteers, competitors and team supervisors. To get the 'Team Supervisor' role on Discord please reply to this email with your Discord username once you have joined the server and we will add the appropriate roles.
 
-Whilst most of the discussions and support will be happening on Discord, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.
+Whilst most of the discussions and support will be happening on Discord, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer. Additionally for SR2023 some elements of the competition will require posting to Discord, so please do encourage your team to join. If you are unable to do this, please [let us know](mailto:teams@studentrobotics.org) so we can work out alternative ways to accommodate your team.

--- a/SR2023/2022-10-18-discord-credentials.md
+++ b/SR2023/2022-10-18-discord-credentials.md
@@ -1,0 +1,16 @@
+---
+to: Student Robotics 2023 teams
+subject: Student Robotics Discord Forum Details
+---
+
+Hi
+
+This year, we're using [Discord](https://studentrobotics.org/docs/team_admin/discord) as our primary communication method for competitor support. Your invite link is [discord link](). If you don't already have a Discord account, you can register an account for free.
+
+Upon joining the server users will need to provide a password to gain the correct permissions. The password is used to identify which team a user is from, so do not share to those outside your team. For your team, the password is: `password`. Please share both the invite link and the relevant password with your competitors.
+
+More information on this can be found in [the docs](https://studentrobotics.org/docs/team_admin/discord).
+
+Additionally, we like to make sure we are aware which members are volunteers, competitors and team supervisors. To get the 'Team Supervisor' role on Discord please reply to this email with your Discord username once you have joined the server and we will add the appropriate roles.
+
+Whilst most of the discussions and support will be happening on Discord, if you are unable to or do not wish to create an account with Discord you can still [contact us](mailto:teams@studentrobotics.org) for support, however the response times will be longer.


### PR DESCRIPTION
This is copied from [last year's email](https://github.com/srobo/team-emails/blob/master/SR2022/2021-11-12-discord-credentials.md), but without mentioning the #role-requests channel. This is as we have no institutions with two teams this year there should be no need to change roles.

Fixes https://github.com/srobo/tasks/issues/946