### PR TITLE
Add pre-shipping kit update for this year

### DIFF
--- a/SR2023/2022-11-04-pre-shipping-kit-update.md
+++ b/SR2023/2022-11-04-pre-shipping-kit-update.md
@@ -1,0 +1,15 @@
+---
+to: Student Robotics 2023 teams without kits who have submitted disclaimers
+subject: Kit update
+---
+
+Hi,
+
+Thank you for sending in your kit disclaimer and confirming your postal address.
+We're in the process of finalising the kit for your team and arranging shipping.
+We apologise for the delay in getting your kit sent out and hope to have a
+further update for you early next week.
+
+Thanks,
+
+-- SR Competition Team


### PR DESCRIPTION
A number of the teams have (quite reasonably) asked for an update on their kits given that we're now two weeks after Kickstart and they've not heard anything.