### PR TITLE
Add email requesting secondary contact details

### DIFF
--- a/SR2023/2022-11-07-secondary-contact.md
+++ b/SR2023/2022-11-07-secondary-contact.md
@@ -1,0 +1,24 @@
+---
+to: Student Robotics 2023 teams who do not have a secondary contact
+subject: Team's secondary contact
+---
+
+Hi,
+
+We're in the process of sending out kits to teams, however we don't have a
+valid secondary contact for your team.
+
+Please provide a second set of contact details for someone at your institution
+(e.g: head of department). They should know about the competition, and can be
+used as a backup contact. It should be an individual, rather than a generic
+school office number.
+
+- Name
+- Email
+- Phone number
+
+
+Secondary contacts are important for us in the event of an emergency. Once we
+have this information, we can get your kit dispatched to you.
+
+Thanks,


### PR DESCRIPTION
Secondary contacts are a prerequisite for sending kits, as they're massively helpful when reclaiming kits.