### PR TITLE
Add an email to teams about the kit update which fixes marker sizes

### DIFF
--- a/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
+++ b/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
@@ -34,5 +34,5 @@ section of Discord.
 -- the SR Team
 
 [sr-os-update]: https://studentrobotics.org/docs/kit/brain_board/updates
-[markers-pdfs]: https://studentrobotics.org/docs/resources/2023/markers
+[markers-pdfs]: https://studentrobotics.org/docs/programming/sr/vision/markers
 [blog-post]: https://studentrobotics.org/blog/2022-12-01-kit-os-2023.1.0

--- a/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
+++ b/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
@@ -1,0 +1,37 @@
+---
+to: Student Robotics 2023 teams
+subject: "Kit update: marker size update and more"
+---
+
+Hi,
+
+We've released version [2023.1.0 of SR OS][sr-os-update], the software which
+runs on the brain board. This includes a number of changes to the vision system,
+including the update for the recent marker (and token) size change.
+
+As you are hopefully already aware, markers are now 80mm (down from 100mm) and
+the Bronze & Silver tokens are 130 ±10mm (up from 110mm).
+
+Along with this change we have also released new versions of the
+[marker PDFs][markers-pdfs] for use in developing your robots.
+
+Once again we apologise for this change and recognise that it may impact robots
+that you had already started building.
+
+As we noted previously, the distance and position information for these smaller
+markers should be essentially unchanged versus the larger ones, as long as the
+new kit software is used exclusively with the new markers (and vice-versa).
+
+This update also includes tooling to understand what your code is doing
+("interactive debugging"), improvements to how often the vision system detects
+markers and much more. For details of these changes and how to apply it to your
+kits please see our latest [blog post][blog-post].
+
+If you or your team have any questions please do post them in the support
+section of Discord.
+
+-- the SR Team
+
+[sr-os-update]: https://studentrobotics.org/docs/kit/brain_board/updates
+[markers-pdfs]: https://studentrobotics.org/docs/resources/2023/markers
+[blog-post]: https://studentrobotics.org/blog/2022-11-26-kit-os-2023.1.0

--- a/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
+++ b/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
@@ -1,6 +1,6 @@
 ---
 to: Student Robotics 2023 teams
-subject: "Kit update: marker size update and more"
+subject: "Kit software update: marker size update and more"
 ---
 
 Hi,

--- a/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
+++ b/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
@@ -5,9 +5,10 @@ subject: "Kit update: marker size update and more"
 
 Hi,
 
-We've released version [2023.1.0 of SR OS][sr-os-update], the software which
-runs on the brain board. This includes a number of changes to the vision system,
-including the update for the recent marker (and token) size change.
+We're delighted to announce the release of [version 2023.1.0][sr-os-update] of
+the Student Robotics OS, the software which runs on the brain board. This
+includes a number of changes to the vision system, including the update for the
+recent marker (and token) size change.
 
 As you are hopefully already aware, markers are now 80mm (down from 100mm) and
 the Bronze & Silver tokens are 130 ±10mm (up from 110mm).

--- a/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
+++ b/SR2023/2022-11-26-kit-update-marker-sizes-and-more.md
@@ -35,4 +35,4 @@ section of Discord.
 
 [sr-os-update]: https://studentrobotics.org/docs/kit/brain_board/updates
 [markers-pdfs]: https://studentrobotics.org/docs/resources/2023/markers
-[blog-post]: https://studentrobotics.org/blog/2022-11-26-kit-os-2023.1.0
+[blog-post]: https://studentrobotics.org/blog/2022-12-01-kit-os-2023.1.0


### PR DESCRIPTION
This follows from the rules update 10 days ago and lines up with the kit updates and blog post we're about to publish.

Blocked on:
- [x] the image being ready & published https://github.com/srobo/docs/pull/416
- [ ] the blog post being published and ensuring that we link to the correct url https://github.com/srobo/website/pull/464

This is deliberately light on the details of the update itself, aside from the marker size update as this is the one that's most breaking and likely most pertinent to teams. It's also the aspect we had recently promised, so this is more of a follow-up to that promise than a generic announcement.