### PR TITLE
Add kit recovery email

### DIFF
--- a/SR2023/2023-04-25-kit-recovery.md
+++ b/SR2023/2023-04-25-kit-recovery.md
@@ -1,0 +1,30 @@
+---
+to: Teams with outstanding kit
+subject: Outstanding kit
+---
+
+Hello!
+
+According to our records, you still have a kit from this years competition. As the competition has ended, we would like this back!
+
+Please securely pack the kit and ship it to the address listed on [our website](https://studentrobotics.org/contact/). You can find a list of the parts to return attached to this email or [on our website](https://studentrobotics.org/docs/kit/).
+
+Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
+
+## How to ship your kit
+
+- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
+- All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
+- Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
+- Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.
+
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
+
+Kit data for couriers:
+
+- Dimensions: 48cm x 39cm x 20cm
+- Weight: 6kg
+- Value (for insurance): £500
+- Batteries: Lithium Ion. Packed with equipment. Batteries less than 100Wh.
+
+If you have any questions, please let us know as soon as possible!


### PR DESCRIPTION
Send an email with instructions on kit return. This is based on the instructions we sent in 2019.

Attachment: [SR2023 Return List-1.pdf](https://github.com/srobo/team-emails/files/11325661/SR2023.Return.List-1.pdf)
