### PR TITLE
An email confirming places for SR2024

### DIFF
--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -15,12 +15,11 @@ around the UK. These provide an opportunity for your team to get hands-on help
 from our volunteer mentors, make progress on their robot and meet other teams.
 
 Throughout the year your team will be able to get support for our mentors via
-[Discord](https://studentrobotics.org/docs/tutorials/discord). In addition to
-shared channels where any team can ask questions, each team will have their own
-private text chat channel and team supervisors can request voice & video
-channels too. These offer a space for teams to discuss their robot and get
-direct support from our mentors at any time. We will send out invites to Discord
-separately.
+[Discord][discord]. In addition to shared channels where any team can ask
+questions, each team will have their own private text chat channel and team
+supervisors can request voice & video channels too. These offer a space for
+teams to discuss their robot and get direct support from our mentors at any
+time. We will send out invites to Discord separately.
 
 This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
 to watch the presentations, get to know each other and start working together on
@@ -51,3 +50,4 @@ We look forward to seeing you at [Kickstart][kickstart]!
 -- SR Competition Committee
 
 [kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/
+[discord]: https://studentrobotics.org/docs/tutorials/discord

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -52,6 +52,9 @@ The shipping address we have for you is:
 
     SHIPPING_ADDRESS
 
+So that your kit arrives in time for Kickstart please ensure we have the
+necessary details by 1st October.
+
 We'll send out more information about this year's [Discord][discord] server and
 [Kickstart][kickstart] event in the coming weeks. We look forward to seeing you
 then!

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -6,9 +6,9 @@ subject: Confirming your place at Student Robotics 2024
 You're in! We're happy to confirm you've got a place at Student Robotics 2024!
 
 As the new school year starts, so does Student Robotics. The year starts with a
-"[Kickstart](https://studentrobotics.org/events/sr2024/virtual-kickstart/)"
-event which gives competitors and team supervisors an introduction to this
-year's competition and overview of how to build and engineer their robot.
+"[Kickstart][kickstart]" event which gives competitors and team supervisors an
+introduction to this year's competition and overview of how to build and
+engineer their robot.
 
 At various points in the year we will have a number of "Tech Days" at locations
 around the UK. These provide an opportunity for your team to get hands-on help
@@ -46,6 +46,8 @@ The shipping address we have for you is:
 
     SHIPPING_ADDRESS
 
-We look forward to seeing you at Kickstart!
+We look forward to seeing you at [Kickstart][kickstart]!
 
 -- SR Competition Committee
+
+[kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -32,9 +32,16 @@ competitors with the kit, which the teams can complete afterwards. There will be
 mentors around in Discord throughout the day to support teams working through
 these tasks.
 
-To receive your kit we need a _secondary contact_ for your team. This should be
-someone at your institution (e.g: head of department). They should know about
-the competition, and be able to act as a backup contact.
+To receive your kit we need a few things from you:
+
+- A _secondary contact_ for your team. This should be someone at your
+  institution (e.g: head of department). They should know about the
+  competition, and be able to act as a backup contact.
+- You need to agree to our _kit disclaimer_ (PDF attached). This disclaimer
+  covers the terms and conditions under which you may use the kit and outlines
+  the limits of our responsibilities. Please sign it, scan it and email it back
+  to us.
+- Confirmation of your _shipping address_.
 
 Please fill in this form to confirm your shipping address and provide details of
 your secondary contact:

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -52,7 +52,9 @@ The shipping address we have for you is:
 
     SHIPPING_ADDRESS
 
-We look forward to seeing you at [Kickstart][kickstart]!
+We'll send out more information about this year's [Discord][discord] server and
+[Kickstart][kickstart] event in the coming weeks. We look forward to seeing you
+then!
 
 -- SR Competition Committee
 

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -1,0 +1,51 @@
+---
+to: Student Robotics 2024
+subject: Confirming your place at Student Robotics 2024
+---
+
+You're in! We're happy to confirm you've got a place at Student Robotics 2024!
+
+As the new school year starts, so does Student Robotics. The year starts with a
+"Kickstart" event which gives competitors and team supervisors an introduction
+to this year's competition and overview of how to build and engineer their
+robot.
+
+At various points in the year we will have a number of "Tech Days" at locations
+around the UK. These provide an opportunity for your team to get hands-on help
+from our volunteer mentors, make progress on their robot and meet other teams.
+
+Throughout the year your team will be able to get support for our mentors via
+[Discord](https://studentrobotics.org/docs/tutorials/discord). In addition to
+shared channels where any team can ask questions, each team will have their own
+private text chat channel and team supervisors can request voice & video
+channels too. These offer a space for teams to discuss their robot and get
+direct support from our mentors at any time. We will send out invites to Discord
+separately.
+
+This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
+to watch the presentations, get to know each other and start working together on
+the kit. We will be shipping kits out to teams ahead of the event, so
+_please ensure we have the correct shipping address_.
+
+On the day we will be livestreaming an introduction to the competition, the game
+and the kits. We will also be providing a set of tasks which will familiarise
+competitors with the kit, which the teams can complete afterwards. There will be
+mentors around in Discord throughout the day to support teams working through
+these tasks.
+
+To receive your kit we need a _secondary contact_ for your team. This should be
+someone at your institution (e.g: head of department). They should know about
+the competition, and be able to act as a backup contact.
+
+Please fill in this form to confirm your shipping address and provide details of
+your secondary contact:
+
+    https://forms.gle/jgJ6fhspWUNyWR5X9
+
+The shipping address we have for you is:
+
+    SHIPPING_ADDRESS
+
+We look forward to seeing you at Kickstart!
+
+-- SR Competition Committee

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -6,9 +6,9 @@ subject: Confirming your place at Student Robotics 2024
 You're in! We're happy to confirm you've got a place at Student Robotics 2024!
 
 As the new school year starts, so does Student Robotics. The year starts with a
-"Kickstart" event which gives competitors and team supervisors an introduction
-to this year's competition and overview of how to build and engineer their
-robot.
+"[Kickstart](https://studentrobotics.org/events/sr2024/virtual-kickstart/)"
+event which gives competitors and team supervisors an introduction to this
+year's competition and overview of how to build and engineer their robot.
 
 At various points in the year we will have a number of "Tech Days" at locations
 around the UK. These provide an opportunity for your team to get hands-on help


### PR DESCRIPTION
This deliberately includes a lot more information than we have in these emails in the past, hopefully this will be useful for any rookie teams that we have (given that this will be the first email they've ever had from us).

TODO:
- https://github.com/srobo/team-emails/pull/151
- add something clarifying that the kit is _loaned_ to teams
