### PR TITLE
Slight tweaks to SR2024 Teams confirmation

### DIFF
--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -6,31 +6,9 @@ subject: Confirming your place at Student Robotics 2024
 You're in! We're happy to confirm you've got a place at Student Robotics 2024!
 
 As the new school year starts, so does Student Robotics. The year starts with a
-"[Kickstart][kickstart]" event which gives competitors and team supervisors an
+virtual "[Kickstart][kickstart]" event which gives competitors and team supervisors an
 introduction to this year's competition and overview of how to build and
 engineer their robot.
-
-At various points in the year we will have a number of "Tech Days" at locations
-around the UK. These provide an opportunity for your team to get hands-on help
-from our volunteer mentors, make progress on their robot and meet other teams.
-
-Throughout the year your team will be able to get support for our mentors via
-[Discord][discord]. In addition to shared channels where any team can ask
-questions, each team will have their own private text chat channel and team
-supervisors can request voice & video channels too. These offer a space for
-teams to discuss their robot and get direct support from our mentors at any
-time. We will send out invites to Discord separately.
-
-This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
-to watch the presentations, get to know each other and start working together on
-the kit. We will be shipping kits out to teams ahead of the event, so
-_please ensure we have the correct shipping address_.
-
-On the day we will be livestreaming an introduction to the competition, the game
-and the kits. We will also be providing a set of tasks which will familiarise
-competitors with the kit, which the teams can complete afterwards. There will be
-mentors around in Discord throughout the day to support teams working through
-these tasks.
 
 To receive your kit we need a few things from you:
 
@@ -55,9 +33,32 @@ The shipping address we have for you is:
 So that your kit arrives in time for Kickstart please ensure we have the
 necessary details by 1st October.
 
-We'll send out more information about this year's [Discord][discord] server and
-[Kickstart][kickstart] event in the coming weeks. We look forward to seeing you
-then!
+This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
+to watch the presentations, get to know each other and start working together on
+the kit. We will be shipping kits out to teams ahead of the event, so
+_please ensure we have the correct shipping address_.
+
+On the day we will be livestreaming an introduction to the competition, the game
+and the kits. We will also be providing a set of tasks which will familiarise
+competitors with the kit, which the teams can complete afterwards. There will be
+mentors around in Discord throughout the day to support teams working through
+these tasks.
+
+At various points in the year we will have a number of "Tech Days" at locations
+around the UK. These provide an opportunity for your team to get hands-on help
+from our volunteer mentors, make progress on their robot, and meet other teams.
+
+Throughout the year your team will be able to get support for our mentors via
+[Discord][discord]. In addition to shared channels where any team can ask
+questions, each team will have their own private text chat channel and team
+supervisors can request voice & video channels too. These offer a space for
+teams to discuss their robot and get direct support from our mentors at any
+time.
+
+We'll send out more information about this year's [Discord][discord] server
+along with an invite link in the coming weeks.
+
+We look forward to seeing you at Kickstart!
 
 -- SR Competition Committee
 


### PR DESCRIPTION
Email looks great, we think tweaking the ordering could improve it. Brings the Kit confirmation to the top as the most time sensitive and important part, then Kickstart, then rest of the year.

ref: https://github.com/srobo/team-emails/pull/150