### PR TITLE
More place confirmation email tweaks

### DIFF
--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -33,16 +33,14 @@ The shipping address we have for you is:
 
     SHIPPING_ADDRESS
 
-This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
-to watch the presentations, get to know each other and start working together on
-the kit. We will be shipping kits out to teams ahead of the event, so
-_please ensure we have the correct shipping address_.
+This year **Kickstart is fully virtual**. On the day we will be livestreaming an
+introduction to the competition, the game and the [robotics kits][kit-docs]. We
+will also be providing a set of tasks which will familiarise competitors with
+the kit. There will be mentors around in [Discord][discord] throughout the day
+to support teams working through these tasks.
 
-On the day we will be livestreaming an introduction to the competition, the game
-and the kits. We will also be providing a set of tasks which will familiarise
-competitors with the kit, which the teams can complete afterwards. There will be
-mentors around in Discord throughout the day to support teams working through
-these tasks.
+We strongly encourage teams to meet up to watch the presentations, get to know
+each other and start working together on the kit.
 
 At various points in the year we will have a number of "Tech Days" at locations
 around the UK. These provide an opportunity for your team to get hands-on help

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -2,7 +2,7 @@
 to: Student Robotics 2024
 subject: Confirming your place at Student Robotics 2024
 attachments:
-  - Kit Disclaimer (PDF)
+  - Kit Disclaimer (PDF): https://drive.google.com/file/d/16JHpd1b1G78GPlfe4tF54as3eyHRytoY/view?usp=sharing
 ---
 
 You're in! We're happy to confirm you've got a place at Student Robotics 2024!

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -56,6 +56,11 @@ time.
 We'll send out more information about this year's [Discord][discord] server
 along with an invite link in the coming weeks.
 
+To ensure that you receive your robotics kit before Kickstart, please provide
+us with the details necessary by 1st October:
+
+    https://forms.gle/jgJ6fhspWUNyWR5X9
+
 We look forward to seeing you at Kickstart!
 
 -- SR Competition Committee

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -10,7 +10,10 @@ virtual "[Kickstart][kickstart]" event which gives competitors and team supervis
 introduction to this year's competition and overview of how to build and
 engineer their robot.
 
-To receive your kit we need a few things from you:
+Ahead of Kickstart we'll send out your loaned [robotics kit][kit-docs], for your
+team to use Kickstart and the competition. To do that we need a few things from
+you. So that your kit can arrive by Kickstart please complete the following by
+1st October:
 
 - A _secondary contact_ for your team. This should be someone at your
   institution (e.g: head of department). They should know about the
@@ -29,9 +32,6 @@ your secondary contact:
 The shipping address we have for you is:
 
     SHIPPING_ADDRESS
-
-So that your kit arrives in time for Kickstart please ensure we have the
-necessary details by 1st October.
 
 This year **Kickstart is fully virtual**. We strongly encourage teams to meet up
 to watch the presentations, get to know each other and start working together on
@@ -64,3 +64,4 @@ We look forward to seeing you at Kickstart!
 
 [kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/
 [discord]: https://studentrobotics.org/docs/tutorials/discord
+[kit-docs]: https://studentrobotics.org/docs/kit/

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -13,9 +13,9 @@ introduction to this year's competition and overview of how to build and
 engineer their robot.
 
 Ahead of Kickstart we'll send out your loaned [robotics kit][kit-docs], for your
-team to use Kickstart and the competition. To do that we need a few things from
-you. So that your kit can arrive by Kickstart please complete the following by
-1st October:
+team to use at Kickstart and the competition. To do that we need a few things
+from you. So that your kit can arrive by Kickstart please complete the following
+by 1st October:
 
 - A _secondary contact_ for your team. This should be someone at your
   institution (e.g: head of department). They should know about the

--- a/SR2024/2023-09-23-place-confirmation.md
+++ b/SR2024/2023-09-23-place-confirmation.md
@@ -1,6 +1,8 @@
 ---
 to: Student Robotics 2024
 subject: Confirming your place at Student Robotics 2024
+attachments:
+  - Kit Disclaimer (PDF)
 ---
 
 You're in! We're happy to confirm you've got a place at Student Robotics 2024!


### PR DESCRIPTION
This picks up most of @WillB97's suggestions on #151, going further in a number of places. It also addresses the desire to clarify that the kit is _loaned_ to teams.

TODO:
- [x] (kinda not blocking, as long as we get it eventually): add the link to the Kit Disclaimer attachment
