### PR TITLE
Emails chasing teams for details for sending their kits

### DIFF
--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -15,7 +15,7 @@ event on Saturday 21st October which gives competitors and team supervisors an
 introduction to this year's competition and overview of how to build and
 engineer their robot.
 
-Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+Ahead of Kickstart we're planning to send out your loaned [robotics kit][kit-docs],
 for your team to use as the core of your robot. As mentioned in our previous
 email confirming your place, we need some details for you before we can do that.
 So that your kit can arrive by Kickstart please complete the following by this

--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -18,7 +18,7 @@ engineer their robot.
 Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
 for your team to use as the core of your robot. To do that we need a few things
 from you. So that your kit can arrive by Kickstart please complete the following
-by **Sunday 1st October**:
+by this **Sunday 1st October**:
 
 - A _secondary contact_ for your team. This should be someone at your
   institution (e.g: head of department). They should know about the

--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -40,7 +40,7 @@ The shipping address we have for you is:
     SHIPPING_ADDRESS
 
 To ensure that you receive your robotics kit before Kickstart, please provide
-us with the details necessary by Sunday 1st October.
+us with the details described above by Sunday 1st October.
 
 -- SR Competition Committee
 

--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -1,6 +1,6 @@
 ---
 to: SR2024 teams who have not confirmed any details
-subject: Details needed to receive your kit for Student Robotics 2024
+subject: "Action Required: Details needed to receive your kit for Student Robotics 2024"
 attachments:
   - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
 ---

--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -1,0 +1,47 @@
+---
+to: SR2024 teams who have not confirmed any details
+subject: Details needed to receive your kit for Student Robotics 2024
+attachments:
+  - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
+---
+
+Hello,
+
+We hope you're as excited about the start of the Student Robotics year as we
+are!
+
+As you're hopefully aware, the year starts with a virtual [Kickstart][kickstart]
+event on Saturday 21st October which gives competitors and team supervisors an
+introduction to this year's competition and overview of how to build and
+engineer their robot.
+
+Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+for your team to use as the core of your robot. To do that we need a few things
+from you. So that your kit can arrive by Kickstart please complete the following
+by **Sunday 1st October**:
+
+- A _secondary contact_ for your team. This should be someone at your
+  institution (e.g: head of department). They should know about the
+  competition, and be able to act as a backup contact.
+- You need to agree to our _kit disclaimer_ (PDF attached). This disclaimer
+  covers the terms and conditions under which you may use the kit and outlines
+  the limits of our responsibilities. Please sign it, scan it and email it back
+  to us.
+- Confirmation of your _shipping address_.
+
+Please fill in this form to confirm your shipping address and provide details of
+your secondary contact:
+
+    https://forms.gle/jgJ6fhspWUNyWR5X9
+
+The shipping address we have for you is:
+
+    SHIPPING_ADDRESS
+
+To ensure that you receive your robotics kit before Kickstart, please provide
+us with the details necessary by Sunday 1st October.
+
+-- SR Competition Committee
+
+[kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/
+[kit-docs]: https://studentrobotics.org/docs/kit/

--- a/SR2024/2023-09-27-chase-details-for-kits.md
+++ b/SR2024/2023-09-27-chase-details-for-kits.md
@@ -16,9 +16,10 @@ introduction to this year's competition and overview of how to build and
 engineer their robot.
 
 Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
-for your team to use as the core of your robot. To do that we need a few things
-from you. So that your kit can arrive by Kickstart please complete the following
-by this **Sunday 1st October**:
+for your team to use as the core of your robot. As mentioned in our previous
+email confirming your place, we need some details for you before we can do that.
+So that your kit can arrive by Kickstart please complete the following by this
+**Sunday 1st October**:
 
 - A _secondary contact_ for your team. This should be someone at your
   institution (e.g: head of department). They should know about the

--- a/SR2024/2023-09-27-chase-kit-disclaimers-only.md
+++ b/SR2024/2023-09-27-chase-kit-disclaimers-only.md
@@ -1,0 +1,34 @@
+---
+to: |
+  SR2024 teams who have submitted the web details form, i.e:
+   - not submitted a kit disclaimer
+   - provided secondary contact details
+   - confirmed their shipping address
+subject: Receiving your kit for Student Robotics 2024
+attachments:
+  - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
+---
+
+Hello,
+
+We hope you're as excited about the start of the Student Robotics year as we
+are!
+
+Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+for your team to use as the core of your robot.
+
+Thank you for submitting your secondary contact details and confirming your
+shipping address.
+
+As a reminder you also need to agree to our _kit disclaimer_ (PDF attached).
+This disclaimer covers the terms and conditions under which you may use the kit
+and outlines the limits of our responsibilities. Please sign it, scan it and
+email it back to us by **Sunday 1st October**.
+
+If we do not receive a signed kit disclaimer by then we cannot guarantee that
+your kit will arrive in time for Kickstart.
+
+-- SR Competition Committee
+
+[kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/
+[kit-docs]: https://studentrobotics.org/docs/kit/

--- a/SR2024/2023-09-27-chase-kit-disclaimers-only.md
+++ b/SR2024/2023-09-27-chase-kit-disclaimers-only.md
@@ -14,7 +14,7 @@ Hello,
 We hope you're as excited about the start of the Student Robotics year as we
 are!
 
-Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+Ahead of Kickstart we're planning to send out your loaned [robotics kit][kit-docs],
 for your team to use as the core of your robot.
 
 Thank you for submitting your secondary contact details and confirming your

--- a/SR2024/2023-09-27-chase-kit-disclaimers-only.md
+++ b/SR2024/2023-09-27-chase-kit-disclaimers-only.md
@@ -23,7 +23,7 @@ shipping address.
 As a reminder you also need to agree to our _kit disclaimer_ (PDF attached).
 This disclaimer covers the terms and conditions under which you may use the kit
 and outlines the limits of our responsibilities. Please sign it, scan it and
-email it back to us by **Sunday 1st October**.
+email it back to us by this **Sunday 1st October**.
 
 If we do not receive a signed kit disclaimer by then we cannot guarantee that
 your kit will arrive in time for Kickstart.

--- a/SR2024/2023-09-27-chase-kit-disclaimers-only.md
+++ b/SR2024/2023-09-27-chase-kit-disclaimers-only.md
@@ -4,7 +4,7 @@ to: |
    - not submitted a kit disclaimer
    - provided secondary contact details
    - confirmed their shipping address
-subject: Receiving your kit for Student Robotics 2024
+subject: "Action Required: Receiving your kit for Student Robotics 2024"
 attachments:
   - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
 ---

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -1,0 +1,43 @@
+---
+to: |
+  SR2024 teams who have not submitted the web details form, i.e:
+   - submitted a kit disclaimer
+   - not provided secondary contact details
+   - not confirmed their shipping address
+subject: Receiving your kit for Student Robotics 2024
+attachments:
+  - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
+---
+
+Hello,
+
+We hope you're as excited about the start of the Student Robotics year as we
+are!
+
+Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+for your team to use as the core of your robot.
+
+Thank you for submitting your kit disclaimer, as a reminder please complete the
+following by **Sunday 1st October**:
+
+- A _secondary contact_ for your team. This should be someone at your
+  institution (e.g: head of department). They should know about the
+  competition, and be able to act as a backup contact.
+- Confirmation of your _shipping address_.
+
+Please fill in this form to confirm your shipping address and provide details of
+your secondary contact:
+
+    https://forms.gle/jgJ6fhspWUNyWR5X9
+
+The shipping address we have for you is:
+
+    SHIPPING_ADDRESS
+
+To ensure that you receive your robotics kit before Kickstart, please provide
+us with the details necessary by Sunday 1st October.
+
+-- SR Competition Committee
+
+[kickstart]: https://studentrobotics.org/events/sr2024/virtual-kickstart/
+[kit-docs]: https://studentrobotics.org/docs/kit/

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -4,7 +4,7 @@ to: |
    - submitted a kit disclaimer
    - not provided secondary contact details
    - not confirmed their shipping address
-subject: Receiving your kit for Student Robotics 2024
+subject: "Action Required: Receiving your kit for Student Robotics 2024"
 attachments:
   - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
 ---

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -18,7 +18,7 @@ Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs
 for your team to use as the core of your robot.
 
 Thank you for submitting your kit disclaimer, as a reminder please complete the
-following by **Sunday 1st October**:
+following by this **Sunday 1st October**:
 
 - A _secondary contact_ for your team. This should be someone at your
   institution (e.g: head of department). They should know about the

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -33,7 +33,7 @@ The shipping address we have for you is:
     SHIPPING_ADDRESS
 
 To ensure that you receive your robotics kit before Kickstart, please provide
-us with the details necessary by Sunday 1st October.
+us with the details described above by Sunday 1st October.
 
 -- SR Competition Committee
 

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -12,7 +12,7 @@ Hello,
 We hope you're as excited about the start of the Student Robotics year as we
 are!
 
-Ahead of Kickstart we'd planning to send out your loaned [robotics kit][kit-docs],
+Ahead of Kickstart we're planning to send out your loaned [robotics kit][kit-docs],
 for your team to use as the core of your robot.
 
 Thank you for submitting your kit disclaimer, as a reminder please complete the

--- a/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
+++ b/SR2024/2023-09-27-chase-secondary-contacts-and-shipping-address.md
@@ -5,8 +5,6 @@ to: |
    - not provided secondary contact details
    - not confirmed their shipping address
 subject: "Action Required: Receiving your kit for Student Robotics 2024"
-attachments:
-  - Kit Disclaimer (PDF): https://drive.google.com/file/d/1a4Uh3O5qYElmA_QPztpVyvAByUGf4T3H/view
 ---
 
 Hello,


### PR DESCRIPTION
This adds three emails for teams who have submitted varying levels of information:

- those who we've not heard from
- those who submitted just a disclaimer (via email)
- those who submitted just contact & address details (web form)
