### PR TITLE
Announce Virtual Comp, Mentoring, and Rules

### DIFF
--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -15,7 +15,7 @@ The virtual competition is an opportunity for your teams to test their coding sk
 
 The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
-The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT.
+The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym: <TLA merges in here>, and the password is the same as the password your team used to enter Discord.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -15,7 +15,7 @@ The virtual competition is an opportunity for your teams to test their coding sk
 
 The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
-The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TLA mailmerges in here>, and the password is the same as the password your team used to enter Discord.
+The code submission deadline will be **two days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TLA mailmerges in here>, and the password is the same as the password your team used to enter Discord.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -11,7 +11,7 @@ We hope your team found Kickstart useful and are excited for the year ahead - we
 
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
-The matches played at the virtual competition are the first matches in the main competition leagues, so points earned at the virtual competition contribute to a team's success at the physical competition. It is also an opportunity for your teams to test their coding skills before the physical competition takes place.
+The matches played at the virtual competition are the first matches in the main competition league, so points earned at the virtual competition contribute to a team's success at the physical competition. It is also an opportunity for your teams to test their coding skills before the physical competition takes place.
 
 The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -1,11 +1,11 @@
 ---
 to: Student Robotics 2024
-subject: SR2024 Virtual Competition, Mentoring, and rules changes
+subject: SR2024 Virtual Competition, Mentoring, and Rules changes
 ---
 
 Hello! 
 
-We hope your team found Kickstart useful and are excited for the year ahead - we certainly are, and we have a couple things to announce that will happen along the way:
+We hope your team found Kickstart useful and are excited for the year ahead - we certainly are, and we have a few things to announce that will happen along the way:
 
 # Virtual Competition
 
@@ -13,7 +13,7 @@ We're happy to announce that in addition to our physical competition, we'll be h
 
 The virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
 
-The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
+The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
 The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TLA mailmerges in here>, and the password is the same as the password your team used to enter Discord.
 
@@ -35,7 +35,7 @@ We would also like one of your students to post a short report in your team's Di
 
 # Rules amendments
 
-We've also made some minor amendments to the rules which are worth noting:
+We've also made some minor amendments to the [rules](https://srobo.org/rules/) which are worth noting:
 
 - Added the definition of the league ran in the virtual competition.
 - Narrowed definitions of objects "in" spaceships and robots to handle situations when spaceships are picked up by robots.

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -29,7 +29,7 @@ This year, we'd like to offer mentoring support through the year. Mentoring supp
 
 Please fill out the form below to register an interest in mentoring. While we can't guarantee regular support, we'll do our best to match you with a volunteer as soon as we're able.
 
-<FORM LINK GOES HERE>
+https://forms.gle/V831FNHaMLC4h4pVA
 
 We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you/your teams are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -5,6 +5,10 @@ subject: SR2024 Virtual Competition
 
 Hello! 
 
+We hope your team found Kickstart useful and are excited for the year ahead - we certainly are, and we have a couple things to announce that will happen along the way:
+
+# Virtual Competition
+
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
 The virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
@@ -18,3 +22,16 @@ During the competition, your robot will compete in (at least) 4 virtual matches 
 We'll keep the [virtual competition event page](https://studentrobotics.org/events/sr2024/virtual-competition) up-to-date with more information about the event.
 
 We have made an amendment to our rules to add further details.
+
+# Mentoring
+
+This year, we'd like to offer mentoring support through the year. Mentoring support from one of our volunteers can be invaluable in terms of helping understand the kit, rules and competition; in encouraging and pushing your teams; and as enthusiastic role models.
+
+Please fill out the form below to register an interest in mentoring. While we can't guarantee regular support, we'll do our best to match you with a volunteer as soon as we're able.
+
+<FORM LINK GOES HERE>
+
+We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you/your teams are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
+
+Regards,
+- The Competition Team

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -40,4 +40,5 @@ We've also made some minor amendments to the [rules](https://srobo.org/rules/) w
 - Clarified that the challenges cannot be completed in the simulator.
 
 Regards,
-- The Competition Team
+
+-- the Competition Team

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -11,13 +11,11 @@ We hope your team found Kickstart useful and are excited for the year ahead - we
 
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
-The virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
+The matches played at the virtual competition are the first matches in the main competition leagues, so points earned at the virtual competition contribute to a team's success at the physical competition. It is also an opportunity for your teams to test their coding skills before the physical competition takes place.
 
 The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
 The code submission deadline will be **two days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TODO_TLA_HERE>, and the password is the same as the password your team used to enter Discord.
-
-During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 
 We'll keep the [virtual competition event page](https://studentrobotics.org/events/sr2024/virtual-competition) up-to-date with more information about the event.
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -15,7 +15,7 @@ The virtual competition is an opportunity for your teams to test their coding sk
 
 The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
-The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym: <TLA merges in here>, and the password is the same as the password your team used to enter Discord.
+The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TLA mailmerges in here>, and the password is the same as the password your team used to enter Discord.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -1,6 +1,6 @@
 ---
 to: Student Robotics 2024
-subject: SR2024 Virtual Competition
+subject: SR2024 Virtual Competition, Mentoring, and rules changes
 ---
 
 Hello! 
@@ -32,6 +32,14 @@ Please fill out the form below to register an interest in mentoring. While we ca
 https://forms.gle/V831FNHaMLC4h4pVA
 
 We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you/your teams are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
+
+# Rules amendments
+
+We've also made some minor amendments to the rules which are worth noting:
+
+- Added the definition of the league ran in the virtual competition.
+- Narrowed definitions of objects "in" spaceships and robots to handle situations when spaceships are picked up by robots.
+- Clarified that the challenges cannot be completed in the simulator.
 
 Regards,
 - The Competition Team

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -3,7 +3,7 @@ to: Student Robotics 2024
 subject: SR2024 Virtual Competition, Mentoring, and Rules changes
 ---
 
-Hello! 
+Hello!
 
 We hope your team found Kickstart useful and are excited for the year ahead - we certainly are, and we have a few things to announce that will happen along the way:
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -7,7 +7,7 @@ Hello!
 
 We hope your team found Kickstart useful and are excited for the year ahead - we certainly are, and we have a few things to announce that will happen along the way:
 
-# Virtual Competition
+## Virtual Competition
 
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
@@ -21,7 +21,7 @@ We'll keep the [virtual competition event page](https://studentrobotics.org/even
 
 We have made an amendment to our rules to add further details.
 
-# Mentoring
+## Mentoring
 
 This year, we'd like to offer mentoring support through the year. Mentoring support from one of our volunteers can be invaluable in terms of helping understand the kit, rules and competition; in encouraging and pushing your team; and as enthusiastic role models.
 
@@ -31,7 +31,7 @@ https://forms.gle/V831FNHaMLC4h4pVA
 
 We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you or your team are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
 
-# Rules amendments
+## Rules amendments
 
 We've also made some minor amendments to the [rules](https://srobo.org/rules/) which are worth noting:
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -11,7 +11,7 @@ We hope your team found Kickstart useful and are excited for the year ahead - we
 
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
-The matches played at the virtual competition are the first matches in the main competition league, so points earned at the virtual competition contribute to a team's success at the physical competition. It is also an opportunity for your teams to test their coding skills before the physical competition takes place.
+The matches played at the virtual competition are the first matches in the main competition league, so points earned at the virtual competition contribute to a team's success at the physical competition. It is also an opportunity for your team to test their coding skills before the physical competition takes place.
 
 The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
@@ -23,13 +23,13 @@ We have made an amendment to our rules to add further details.
 
 # Mentoring
 
-This year, we'd like to offer mentoring support through the year. Mentoring support from one of our volunteers can be invaluable in terms of helping understand the kit, rules and competition; in encouraging and pushing your teams; and as enthusiastic role models.
+This year, we'd like to offer mentoring support through the year. Mentoring support from one of our volunteers can be invaluable in terms of helping understand the kit, rules and competition; in encouraging and pushing your team; and as enthusiastic role models.
 
 Please fill out the form below to register an interest in mentoring. While we can't guarantee regular support, we'll do our best to match you with a volunteer as soon as we're able.
 
 https://forms.gle/V831FNHaMLC4h4pVA
 
-We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you/your teams are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
+We would also like one of your students to post a short report in your team's Discord channel after they meet so we are better able to offer help. If you or your team are not yet in [Discord](https://studentrobotics.org/docs/tutorials/discord.html) and you need help, please let us know.
 
 # Rules amendments
 

--- a/SR2024/2023-11-08-virtual-competition-and-mentoring.md
+++ b/SR2024/2023-11-08-virtual-competition-and-mentoring.md
@@ -15,7 +15,7 @@ The virtual competition is an opportunity for your teams to test their coding sk
 
 The matches will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
-The code submission deadline will be **two days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TLA mailmerges in here>, and the password is the same as the password your team used to enter Discord.
+The code submission deadline will be **two days before**, that's Thursday 7th March 2024 at 6pm GMT. Your team can submit their robot code to [the code submitter](https://studentrobotics.org/code-submitter/). The log in details have the username of your team's three letter acronym (in upper case): <TODO_TLA_HERE>, and the password is the same as the password your team used to enter Discord.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -9,9 +9,9 @@ We're happy to announce that in addition to our physical competition, we'll be h
 
 The Virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
 
-The results will be broadcast live on **Saturday 9th March 2023 at 1pm** via a livestream on our YouTube channel.
+The results will be broadcast live on **Saturday 9th March 2024 at 1pm** via a livestream on our YouTube channel.
 
-The code submission deadline will be **2 days before**, that's at 6pm on Thursday 7th March 2023.
+The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -15,4 +15,6 @@ The code submission deadline will be **2 days before**, that's Thursday 7th Marc
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 
+We'll keep the [virtual competition event page](https://studentrobotics.org/events/sr2024/virtual-competition) up-to-date with more information about the event.
+
 We have made an amendment to our rules to add further details.

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -9,7 +9,7 @@ We're happy to announce that in addition to our physical competition, we'll be h
 
 The virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
 
-The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a livestream on our YouTube channel.
+The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a [livestream](https://www.youtube.com/watch?v=hlfaQIfLaRg) on our YouTube channel.
 
 The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT.
 

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -9,9 +9,9 @@ We're happy to announce that in addition to our physical competition, we'll be h
 
 The Virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
 
-The results will be broadcast live on **Saturday 9th March 2024 at 1pm** via a livestream on our YouTube channel.
+The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a livestream on our YouTube channel.
 
-The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm.
+The code submission deadline will be **2 days before**, that's Thursday 7th March 2024 at 6pm GMT.
 
 During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
 

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -1,0 +1,18 @@
+---
+to: Student Robotics 2024
+subject: SR2024 Virtual Competition
+---
+
+Hello! 
+
+We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
+
+The Virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
+
+The results will be broadcast live on **Saturday 9th March 2023 at 1pm** via a livestream on our YouTube channel.
+
+The code submission deadline will be **2 days before**, that's at 6pm on Thursday 7th March 2023.
+
+During the competition, your robot will compete in (at least) 4 virtual matches for real league points, these points will then transfer across to the physical competition!
+
+We have made an amendment to our rules to add further details.

--- a/SR2024/2023-11-08-virtual-competition-announcement.md
+++ b/SR2024/2023-11-08-virtual-competition-announcement.md
@@ -7,7 +7,7 @@ Hello!
 
 We're happy to announce that in addition to our physical competition, we'll be holding a **virtual competition**. We'll run our virtual competition on our [robot simulator](https://studentrobotics.org/docs/simulator/).
 
-The Virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
+The virtual competition is an opportunity for your teams to test their coding skills before the physical competition takes place.
 
 The results will be broadcast live on **Saturday 9th March 2024 at 1pm GMT**  via a livestream on our YouTube channel.
 


### PR DESCRIPTION
Add an email announcing the virtual competition

TODO:
- [x] Add a livestream link (once we have a livestream set up)
- [x] Add a link to the event page on the site once we have that up. 
- [x] Add the rules revision to the bottom 