### PR TITLE
Add a chase email for teams who haven't RSVP'd

### DIFF
--- a/SR2024/2024-03-06-competition-attendance-followup.md
+++ b/SR2024/2024-03-06-competition-attendance-followup.md
@@ -9,7 +9,7 @@ We're working hard getting [the competition event][competition-event] ready for 
 
 We understand you might not know the exact number of team members who will attend, so vague guesses are absolutely fine for now! You'll be able to edit your response until our plans are finalised. If you still want to make changes after that, please send us an email and we'll see what we can do.
 
-[Fill out your team details here](https://forms.gle/8YhfdRbfDWP3KKNy8)
+[Fill out your team details](https://forms.gle/8YhfdRbfDWP3KKNy8)
 
 As ever if your team would like more help & support please do let us know.
 Most teams make a lot of progress as the competition nears, as well as at the event itself, so don't worry if it seems your team still has a lot to do!

--- a/SR2024/2024-03-06-competition-attendance-followup.md
+++ b/SR2024/2024-03-06-competition-attendance-followup.md
@@ -1,0 +1,20 @@
+---
+to: SR2024 teams who haven't RSVP'd
+subject: "Re: Extra Details for the SR2024 Competition event"
+---
+
+Hi,
+
+We're working hard getting [the competition event][competition-event] ready for you. To best support your team, we need to know roughly how large your team is and whether there are any special considerations we need to take for anyone who is coming.
+
+We understand you might not know the exact number of team members who will attend, so vague guesses are absolutely fine for now! You'll be able to edit your response until our plans are finalised. If you still want to make changes after that, please send us an email and we'll see what we can do.
+
+[Fill out your team details here](https://forms.gle/8YhfdRbfDWP3KKNy8)
+
+As ever if your team would like more help & support please do let us know.
+Most teams make a lot of progress as the competition nears, as well as at the event itself, so don't worry if it seems your team still has a lot to do!
+
+Thanks,
+-- SR Competition Team
+
+[competition-event]: https://studentrobotics.org/events/sr2024/competition/


### PR DESCRIPTION
## Summary

Not all teams have replied letting us know how many competitors they're bringing (etc.), so this chases them to do so. This also aims to help flush out any who might want to drop out or who need more help.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
