### PR TITLE
Add email for team assumption survey

### DIFF
--- a/SR2024/2024-03-12-assumption-survey.md
+++ b/SR2024/2024-03-12-assumption-survey.md
@@ -5,7 +5,7 @@ subject: Help us understand what's involved in taking part
 
 Hi all,
 
-We’re gathering some information teams, to understand the positions and opinions teams are in. If you could spare a couple of minutes to fill in this short survey, it would be much appreciated.
+We’re gathering some information from teams, to understand the positions they are in. If you could spare a couple of minutes to fill in this short survey, it would be much appreciated.
 
 Form: https://docs.google.com/forms/d/e/1FAIpQLSciNkavSWTpMm7NsUX0y2FyyElvza3BHNxrYQVsXDKqBJOwkw/viewform
 

--- a/SR2024/2024-03-12-assumption-survey.md
+++ b/SR2024/2024-03-12-assumption-survey.md
@@ -1,0 +1,15 @@
+---
+to: SR2022 teams, SR2023 signups, SR2024 signups
+subject: Team Assumptions Survey
+---
+
+Hi all,
+
+We’re gathering some information teams, to understand the positions and opinions teams are in. If you could spare a couple of minutes to fill in this short survey, it would be much appreciated.
+
+Form: https://docs.google.com/forms/d/e/1FAIpQLSciNkavSWTpMm7NsUX0y2FyyElvza3BHNxrYQVsXDKqBJOwkw/viewform
+
+We hope to be able to use the gathered information to better understand the needs of teams, as well as how we can provide better services.
+
+Thanks,
+-- Student Robotics

--- a/SR2024/2024-03-12-assumption-survey.md
+++ b/SR2024/2024-03-12-assumption-survey.md
@@ -1,6 +1,6 @@
 ---
 to: SR2022 teams, SR2023 signups, SR2024 signups
-subject: Team Assumptions Survey
+subject: Help us understand what's involved in taking part
 ---
 
 Hi all,


### PR DESCRIPTION
## Summary

Sending a survey to teams to confirm our assumptions. We sent a similar form in 2019.

Fixes https://github.com/srobo/committee-tasks/issues/3

Aim to send this to team supervisors who:
- attended SR2022
- signed up for SR2023, SR2024

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
