### PR TITLE
Add an email to chase teams who still haven't RSVP'd

### DIFF
--- a/SR2024/2024-03-13-competition-rsvp-chase.md
+++ b/SR2024/2024-03-13-competition-rsvp-chase.md
@@ -1,0 +1,21 @@
+---
+to: SR2024 teams who still haven't RSVP'd
+subject: SR2024 RSVP & check-in
+---
+
+Hi $TODO_NAME,
+
+{# either #}
+It was great to see your team at the Virtual Competition this weekend.
+{# or #}
+We missed you at the Virtual Competition this weekend.
+{# / #}
+
+I wanted to check on how you're doing and whether you wanted any extra help -- via Discord, in person or otherwise. There's still plenty of time to work on your robot before the competition!
+
+We'd also like to finalise our planning for the competition, including things like assigning team pits at the venue -- for which we need to know a little about the competitors you'll be bringing.
+
+**Please could you [fill out your team details](https://forms.gle/8YhfdRbfDWP3KKNy8) to let us know.**
+
+Thanks,
+Peter


### PR DESCRIPTION
## Summary

There are some teams who still haven't confirmed they're coming to the competition and thus we don't know how many competitors they'll bring nor if they have any special requirements.

These teams are also more likely at risk of dropping out, so we ask if they need any more help too.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [ ] ~Compared to a similar email from the previous year~
- [ ] ~Ensured there's enough context for a rookie team to understand~ (no rookie recipients)
