### PR TITLE
Add final competition details email

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -19,6 +19,7 @@ Aske's
 Collyer's
 COVID-19
 Holles
+Helpdesk
 blueshirt
 blueshirts
 P.S

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -48,7 +48,7 @@ At the competition, all robots undergo a safety check. This not only confirms th
 - Ensure your battery is protected, ideally housed in its own rigid container.
 - Make sure you have a way to mount the flag. We may have a few spare mounts, but please do not rely on this. [Plastic push-fit couplers](https://www.screwfix.com/p/jg-speedfit-plastic-push-fit-equal-tees-15mm-5-pack/74470) work well for this.
 - Make sure your robot fits inside the size constraints. If it doesn't, it will have a meeting with the _saw of shame_.
-- Make sure there are 2 spare USB ports: 1 for your code, and 1 for our "Competition USB". This Competition USB tells your robot that it's in the competition and which corner it's starting in (and thus populates the [`R.zone` property](https://studentrobotics.org/docs/programming/robot_api/#other-robot-attributes)). You will not be able to compete without this.
+- Make sure there are 2 spare USB ports: 1 for your code, and 1 for our "Competition USB". This Competition USB tells your robot that it's in the competition and which corner it's starting in (and thus populates the [`robot.zone` property](https://studentrobotics.org/docs/programming/robot_api/#other-robot-attributes)). You will not be able to compete without this.
 
 All of these and more can be found in our [safety regulations](https://studentrobotics.org/docs/kit/safety-regulations) and [rules](https://studentrobotics.org/rules).
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -1,6 +1,7 @@
 ---
 to: Student Robotics 2024
 subject: SR2024 Competition Details
+attachment: https://drive.google.com/file/d/1JQG_IKOtnvEUPSob1XWTma55FHRK_r4o/view
 ---
 
 Hello everyone!

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -18,7 +18,7 @@ Doors open on both days at 9am and each day will finish around 5:30pm. The event
 
 You'll have access to your pits and the test arena when you arrive, giving your team time to work on their robot before things get going in earnest.
 
-The event is open to the public, so you're welcome to bring family and friends as guests, however please note that space in the pits is limited.
+The event is open to the public, so you're welcome to bring family and friends as guests. However please note that space in the venue is limited, especially in the pits.
 
 We'll be providing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -17,12 +17,14 @@ Thanks to everyone who has already provided their attendance details. If you hav
 Doors open on both days at 9am and each day will finish around 5:30pm. The event will formally start at 10:30am on Saturday. There are now full day schedules on the [event page][competition-event-page]. **If you are expecting to arrive after 10am on Saturday, please let us know.**
 
 You'll have access to your pits and the test arena when you arrive, giving your team time to work on their robot before things get going in earnest.
+Throughout the weekend there will be plenty of volunteers around to help with your robots, prompt you to go to matches and ensure you have a good time.
 
 The event is open to the public, so you're welcome to bring family and friends as guests. However please note that space in the venue is limited, especially in the pits.
 
 We'll be providing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
 
-If you have any issues on the day, we'll be monitoring the `teams@` email address and our Discord server.
+If you have any issues on the day before you arrive, we'll be monitoring the `teams@` email address and our Discord server.
+Within the venue however, please direct queries to Helpdesk instead -- they'll be able to provide more immediate help.
 
 ## Photos & Videos
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -20,7 +20,7 @@ You'll have access to your pits and the test arena when you arrive, giving your 
 
 The event is open to the public, so you're welcome to bring family and friends as guests, however please note that space in the pits is limited.
 
-We'll be publishing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
+We'll be providing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
 
 If you have any issues on the day, we'll be monitoring the `teams@` email address and our Discord server.
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -32,7 +32,7 @@ If you or your competitors would not like to appear in our photos and videos, pl
 
 ## Equipment
 
-Please ensure that your team bring at least one laptop or appropriate device with them to the competition to access the docs and work on your robot's code. We are unable to provide any computing devices for competitor use at the competition. We will be providing a wireless internet connection to all teams.
+Please ensure that your team brings at least one laptop or appropriate device with them to the competition to access the docs and work on your robot's code. We are unable to provide any computing devices for competitor use at the competition. We will be providing a wireless internet connection to all teams.
 
 Any tools that your team requires to modify their robot must be brought to the competition by the team: we cannot provide any. In particular, the use of any dangerous tools must be supervised by the responsible adult for the team. Power tools may only be used in the designated "Power Tools" area.
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -17,11 +17,9 @@ Doors open on both days at 9am and each day will finish around 5:30pm. The event
 
 You'll have access to your pits and the test arena when you arrive, giving your team time to work on their robot before things get going in earnest.
 
-You're welcome to bring family and friends as guests, however please note that space in the pits is limited.
+The event is open to the public, so you're welcome to bring family and friends as guests, however please note that space in the pits is limited.
 
 We'll be publishing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
-
-The competition this year is a public event, and we do not have exclusive access to the venue.
 
 If you have any issues on the day, we'll be monitoring the `teams@` email address and our Discord server.
 

--- a/SR2024/2024-03-15-competition-details.md
+++ b/SR2024/2024-03-15-competition-details.md
@@ -1,0 +1,64 @@
+---
+to: Student Robotics 2024
+subject: SR2024 Competition Details
+---
+
+Hello everyone!
+
+It's just under a month until the big day - [the competition][competition-event-page]!
+
+Before then, we have a few important updates and reminders for you:
+
+## Attendance details
+
+Thanks to everyone who has already provided their attendance details. If you haven't done that yet, or things have changed substantially please [provide attendance details](https://forms.gle/8YhfdRbfDWP3KKNy8).
+
+Doors open on both days at 9am and each day will finish around 5:30pm. The event will formally start at 10:30am on Saturday. There are now full day schedules on the [event page][competition-event-page]. **If you are expecting to arrive after 10am on Saturday, please let us know.**
+
+You'll have access to your pits and the test arena when you arrive, giving your team time to work on their robot before things get going in earnest.
+
+You're welcome to bring family and friends as guests, however please note that space in the pits is limited.
+
+We'll be publishing rules for behaviour in/around the competition venue when you arrive. If you have any questions or concerns beforehand, please let us know.
+
+The competition this year is a public event, and we do not have exclusive access to the venue.
+
+If you have any issues on the day, we'll be monitoring the `teams@` email address and our Discord server.
+
+## Photos & Videos
+
+Throughout the competition, Student Robotics volunteers will be taking photos and videos for the purpose of prompting and marketing the charity. The arena will also be [livestreamed](https://studentrobotics.org/events/sr2024/competition/#livestream) on our YouTube channel. Unlike previous competitions, we will not be issuing Media Consent forms.
+
+If you or your competitors would not like to appear in our photos and videos, please let our reception desk know when you arrive.
+
+## Equipment
+
+Please ensure that your team bring at least one laptop or appropriate device with them to the competition to access the docs and work on your robot's code. We are unable to provide any computing devices for competitor use at the competition. We will be providing a wireless internet connection to all teams.
+
+Any tools that your team requires to modify their robot must be brought to the competition by the team: we cannot provide any. In particular, the use of any dangerous tools must be supervised by the responsible adult for the team. Power tools may only be used in the designated "Power Tools" area.
+
+You must bring all of the robotics kit (including the white box it came in) to the competition, so that we can collect it at the end of the event. We'll be taking both your batteries, the battery charger and battery bag off you when you arrive, so please make sure those are easily accessible. A list of the kit to return is attached to this email.
+
+Teams will be each allocated a _Pit_ -- an area of the venue to work in, with a table to work on and mains outlets. There will also be a _Test Arena_ -- a full size mock arena where teams can test their robots. You will also be able to book _Tinker Time_ slots to test your robot in the real arena.
+
+## Robot design considerations
+
+At the competition, all robots undergo a safety check. This not only confirms that the robot satisfies our safety regulations, but also the rules. Of note are a particular few we often see teams forgetting until the last minute:
+
+- Please make sure the power button is obvious and easily accessible. In the event of an issue in the arena, we don't want to be hunting for the switch as we try and quickly turn off your robot.
+- Ensure your battery is protected, ideally housed in its own rigid container.
+- Make sure you have a way to mount the flag. We may have a few spare mounts, but please do not rely on this. [Plastic push-fit couplers](https://www.screwfix.com/p/jg-speedfit-plastic-push-fit-equal-tees-15mm-5-pack/74470) work well for this.
+- Make sure your robot fits inside the size constraints. If it doesn't, it will have a meeting with the _saw of shame_.
+- Make sure there are 2 spare USB ports: 1 for your code, and 1 for our "Competition USB". This Competition USB tells your robot that it's in the competition and which corner it's starting in (and thus populates the [`R.zone` property](https://studentrobotics.org/docs/programming/robot_api/#other-robot-attributes)). You will not be able to compete without this.
+
+All of these and more can be found in our [safety regulations](https://studentrobotics.org/docs/kit/safety-regulations) and [rules](https://studentrobotics.org/rules).
+
+## Conclusion
+
+If you have any other questions or concerns, please don't hesitate to get in touch.
+
+We look forward to seeing you all at the competition!
+
+-- SR Competition Team
+
+[competition-event-page]: https://studentrobotics.org/events/sr2024/competition/


### PR DESCRIPTION
## Summary

This is probably going to be the last email we bulk send to teams. Normally we'd send this a bit closer to the event, however given the timing of Easter and the related holidays we need to send this a little earlier to hopefully give people time to see it when they're not on holiday and before the event.

Fixes https://github.com/srobo/tasks/issues/1290

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
