### PR TITLE
Add mentoring email for 2025

### DIFF
--- a/SR2025/2024-10-05-mentoring.md
+++ b/SR2025/2024-10-05-mentoring.md
@@ -9,7 +9,7 @@ With the competition soon underway, we’re planning the ways we can help your t
 
 If you would like one of our volunteers to visit your team meetings on a regular basis, either by video chat or in person (where possible), please **[sign up for mentoring](https://forms.gle/tXfZFeuNXP9CnT6v9)**. We will need a responsible adult to be present from your side (yourself, another teacher, a parent, etc.) during these mentoring sessions.
 
-If your team does not currently have scheduled meeting times, you can edit this form later.
+If your team doesn't yet have a regular meeting time, please enter "unconfirmed" in the times, you will be able to edit your response later.
 
 A mentor can guide your team towards good solutions for their robot, provide assistance where they might need it, as well as helping them to understand the kit, the rules, and the competition as a whole.
 

--- a/SR2025/2024-10-05-mentoring.md
+++ b/SR2025/2024-10-05-mentoring.md
@@ -9,6 +9,8 @@ With the competition soon underway, we’re planning the ways we can help your t
 
 If you would like one of our volunteers to visit your team meetings on a regular basis, either by video chat or in person (where possible), please **[sign up for mentoring](https://forms.gle/tXfZFeuNXP9CnT6v9)**. We will need a responsible adult to be present from your side (yourself, another teacher, a parent, etc.) during these mentoring sessions.
 
+If your team does not currently have scheduled meeting times, you can edit this form later.
+
 A mentor can guide your team towards good solutions for their robot, provide assistance where they might need it, as well as helping them to understand the kit, the rules, and the competition as a whole.
 
 Once you've signed up for mentoring, we'll let you know when we find a volunteer who is available for your team's meeting time.

--- a/SR2025/2024-10-05-mentoring.md
+++ b/SR2025/2024-10-05-mentoring.md
@@ -1,0 +1,18 @@
+---
+to: Student Robotics 2025 teams
+subject: Student Robotics 2025 Mentoring
+---
+
+Hello,
+
+With the competition soon underway, we’re planning the ways we can help your teams build the best robots they can. We can support you through individual mentoring.
+
+If you would like one of our volunteers to visit your team meetings on a regular basis, either by video chat or in person (where possible), please **[sign up for mentoring](https://forms.gle/tXfZFeuNXP9CnT6v9)**. We will need a responsible adult to be present from your side (yourself, another teacher, a parent, etc.) during these mentoring sessions.
+
+A mentor can guide your team towards good solutions for their robot, provide assistance where they might need it, as well as helping them to understand the kit, the rules, and the competition as a whole.
+
+Once you've signed up for mentoring, we'll let you know when we find a volunteer who is available for your team's meeting time.
+
+If you have any questions, please let us know!
+
+-- Student Robotics


### PR DESCRIPTION
## Summary

To inform teams mentoring is available.

## Checklist

<!-- Please keep all of these, ~strike~ any which don't apply -->

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
