### PR TITLE
Add email for kit tracking link

### DIFF
--- a/SR2025/2024-10-07-tracking-links.md
+++ b/SR2025/2024-10-07-tracking-links.md
@@ -1,0 +1,16 @@
+---
+to: Student Robotics 2025 teams whose kit has been dispatched
+subject: Your kit is on its way!
+---
+
+Hello,
+
+We've dispatched your kit, and it's on its way to you!
+
+The kits have been dispatched with UPS, and should be with you in the next few days. If you haven't received your kit by next week, please let us know!
+
+You can track your shipment by going to [UPS' website](https://www.ups.com/gb/en/Home.page) and entering your tracking code: {{ tracking_code }}.
+
+Thanks,
+
+-- Student Robotics


### PR DESCRIPTION
## Summary

Once kits are dispatched, we should send teams the tracking code so they can track their kit. They should get email updates anyway, but the tracking link will help.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
