### PR TITLE
Add a check-in email I'd like to send to all teams

### DIFF
--- a/SR2025/2024-11-13-check-in.md
+++ b/SR2025/2024-11-13-check-in.md
@@ -19,7 +19,7 @@ get help much more easily from our volunteers and tend to do better overall.
 As a reminder, if you'd like to come to the [Horsham Tech Day][horsham-tech-day]
 please [let us know][tech-day-signup] this week.
 
-Thanks,
+Thanks,\
 Peter
 
 [horsham-tech-day]: https://studentrobotics.org/events/sr2025/horsham-tech-day-november/

--- a/SR2025/2024-11-13-check-in.md
+++ b/SR2025/2024-11-13-check-in.md
@@ -16,5 +16,11 @@ you'd be able to encourage them to join? Teams which are in Discord are able to
 get help much more easily from our volunteers and tend to do better overall.
 {% endif %}
 
+As a reminder, if you'd like to come to the [Horsham Tech Day][horsham-tech-day]
+please [let us know][tech-day-signup] this week.
+
 Thanks,
 Peter
+
+[horsham-tech-day]: https://studentrobotics.org/events/sr2025/horsham-tech-day-november/
+[tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9

--- a/SR2025/2024-11-13-check-in.md
+++ b/SR2025/2024-11-13-check-in.md
@@ -1,6 +1,6 @@
 ---
 to: SR2025 teams
-subject: SR2025 November Check-in
+subject: Student Robotics 2025 November Check-in
 ---
 
 Hi {PrimaryGivenName},

--- a/SR2025/2024-11-13-check-in.md
+++ b/SR2025/2024-11-13-check-in.md
@@ -1,0 +1,20 @@
+---
+to: SR2025 teams
+subject: SR2025 November Check-in
+---
+
+Hi {PrimaryGivenName},
+
+Just wanted to check in on how your team is doing?
+
+It would be great to hear roughly what stage your team is at, including if
+there's anything you'd like a hand with.
+
+{% if not in discord %}
+We noticed that your team isn't present in Discord -- is this something that
+you'd be able to encourage them to join? Teams which are in Discord are able to
+get help much more easily from our volunteers and tend to do better overall.
+{% endif %}
+
+Thanks,
+Peter

--- a/SR2025/2024-11-13-check-in.md
+++ b/SR2025/2024-11-13-check-in.md
@@ -7,8 +7,8 @@ Hi {PrimaryGivenName},
 
 Just wanted to check in on how your team is doing?
 
-It would be great to hear roughly what stage your team is at, including if
-there's anything you'd like a hand with.
+It would be great to hear what your team is currently working on and if there's
+anything you'd like a hand with.
 
 {% if not in discord %}
 We noticed that your team isn't present in Discord -- is this something that

--- a/scripts/send.py
+++ b/scripts/send.py
@@ -98,13 +98,13 @@ def main(args: argparse.Namespace) -> None:
                 send(
                     server,
                     to=Address(
-                        row['SecondaryName'],
-                        addr_spec=row['SecondaryEmailAddress'],
+                        row['PrimaryName'],
+                        addr_spec=row['PrimaryEmailAddress'],
                     ),
                     cc=[
                         Address(
-                            row['PrimaryName'],
-                            addr_spec=row['PrimaryEmailAddress'],
+                            row['SecondaryName'],
+                            addr_spec=row['SecondaryEmailAddress'],
                         ),
                         SR_TEAMS_ADDRESS,
                     ],

--- a/scripts/send.py
+++ b/scripts/send.py
@@ -95,19 +95,24 @@ def main(args: argparse.Namespace) -> None:
         with args.teams_csv.open() as f:
             reader = csv.DictReader(f)
             for row in reader:
+                cc = [
+                    SR_TEAMS_ADDRESS,
+                ]
+                if row['SecondaryCcSecondary'] == 'TRUE':
+                    cc.append(
+                        Address(
+                            row['SecondaryName'],
+                            addr_spec=row['SecondaryEmailAddress'],
+                        ),
+                    )
+
                 send(
                     server,
                     to=Address(
                         row['PrimaryName'],
                         addr_spec=row['PrimaryEmailAddress'],
                     ),
-                    cc=[
-                        Address(
-                            row['SecondaryName'],
-                            addr_spec=row['SecondaryEmailAddress'],
-                        ),
-                        SR_TEAMS_ADDRESS,
-                    ],
+                    cc=cc,
                     subject=template.subject,
                     html_body=template.template(row),
                     dry_run=args.dry_run


### PR DESCRIPTION
## Summary

Partly this is so that we gather check-in info from all the teams, but also provides a place to ask why they're not in Discord.

I've deliberately kept this short and personliased so it comes across more as a direct email than a mailshot. I'll still send it from teams@.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
