### PR TITLE
SR2025 December check-in email

### DIFF
--- a/SR2025/2024-12-18-check-in.md
+++ b/SR2025/2024-12-18-check-in.md
@@ -13,7 +13,7 @@ anything you'd like a hand with.
 As a reminder, if you'd like to come to the [Cambridge Tech Day][cambridge-tech-day]
 please [let us know][tech-day-signup] this week.
 
-Thanks,\
+Happy holidays,\
 Peter
 
 [cambridge-tech-day]: https://studentrobotics.org/events/sr2025/cambridge-tech-day-january/

--- a/SR2025/2024-12-18-check-in.md
+++ b/SR2025/2024-12-18-check-in.md
@@ -11,7 +11,7 @@ It would be great to hear what your team is currently working on and if there's
 anything you'd like a hand with.
 
 As a reminder, if you'd like to come to the [Cambridge Tech Day][cambridge-tech-day]
-please [let us know][tech-day-signup] this week.
+on Saturday 25th January please [let us know][tech-day-signup] by Friday 17th January.
 
 Happy holidays,\
 Peter

--- a/SR2025/2024-12-18-check-in.md
+++ b/SR2025/2024-12-18-check-in.md
@@ -1,0 +1,20 @@
+---
+to: SR2025 teams
+subject: Student Robotics 2025 {TLA} December Check-in
+---
+
+Hi {PrimaryGivenName},
+
+Just wanted to check in on how your team is doing?
+
+It would be great to hear what your team is currently working on and if there's
+anything you'd like a hand with.
+
+As a reminder, if you'd like to come to the [Cambridge Tech Day][cambridge-tech-day]
+please [let us know][tech-day-signup] this week.
+
+Thanks,\
+Peter
+
+[cambridge-tech-day]: https://studentrobotics.org/events/sr2025/cambridge-tech-day-january/
+[tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9

--- a/scripts/send.py
+++ b/scripts/send.py
@@ -35,7 +35,7 @@ class Template:
     def body(self) -> str:
         return markdown.markdown(self.body_raw).replace('\\\n', '<br>')
 
-    def template(self, mapping: dict[str, str]) -> str:
+    def template_body(self, mapping: dict[str, str]) -> str:
         # Note: this requires manual adjustment of the template and CSV file to
         # have matching names, but that seems fine for now. Perhaps we should
         # move to using Jinja templating or something?
@@ -43,6 +43,12 @@ class Template:
             k: html.escape(v)
             for k, v in mapping.items()
         })
+
+    def template_subject(self, mapping: dict[str, str]) -> str:
+        # Note: this requires manual adjustment of the template and CSV file to
+        # have matching names, but that seems fine for now. Perhaps we should
+        # move to using Jinja templating or something?
+        return self.subject.format(**mapping)
 
 
 def load_template(path: Path) -> Template:
@@ -113,8 +119,8 @@ def main(args: argparse.Namespace) -> None:
                         addr_spec=row['PrimaryEmailAddress'],
                     ),
                     cc=cc,
-                    subject=template.subject,
-                    html_body=template.template(row),
+                    subject=template.template_subject(row),
+                    html_body=template.template_body(row),
                     dry_run=args.dry_run
                 )
 


### PR DESCRIPTION
## Summary

This allows us to check on teams progress, informing us early of any which want to drop out etc.

Mostly a copy from the November one (#201). Once again I've deliberately kept this short and personalised so it comes across more as a direct email than a mailshot. I'll still send it from teams@.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
