### PR TITLE
SR2025 January check-in email

### DIFF
--- a/SR2025/2025-01-15-check-in.md
+++ b/SR2025/2025-01-15-check-in.md
@@ -1,0 +1,27 @@
+---
+to: SR2025 teams
+subject: Student Robotics 2025 {TLA} January Check-in
+---
+
+Hi {PrimaryGivenName},
+
+Happy New Year!
+
+Just wanted to check in on how your team is doing?
+
+It would be great to hear what your team is currently working on and if there's
+anything you'd like a hand with.
+
+A couple of quick reminders for the next few weeks:
+
+* if you'd like to come to the [Cambridge Tech Day][cambridge-tech-day] on
+  Saturday please [let us know][tech-day-signup] this week
+* the second [Challenge Deadline][challenge-deadline] is also coming soon -- get
+  your submissions in by 6pm Saturday 25th to earn another 6 league points
+
+Thanks,\
+Peter
+
+[cambridge-tech-day]: https://studentrobotics.org/events/sr2025/cambridge-tech-day-january/
+[tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9
+[challenge-deadline]: https://studentrobotics.org/events/sr2025/second-challenge-submission-deadline/

--- a/SR2025/2025-01-15-check-in.md
+++ b/SR2025/2025-01-15-check-in.md
@@ -15,7 +15,7 @@ anything you'd like a hand with.
 A couple of quick reminders for the next few weeks:
 
 * if you'd like to come to the [Cambridge Tech Day][cambridge-tech-day] on
-  Saturday please [let us know][tech-day-signup] this week
+  Saturday 25th please [let us know][tech-day-signup] this week
 * the second [Challenge Deadline][challenge-deadline] is also coming soon -- get
   your submissions in by 6pm Saturday 25th to earn another 6 league points
 


### PR DESCRIPTION
## Summary

This allows us to check on teams progress, informing us early of any which want to drop out etc.

Mostly a copy from the November one (https://github.com/srobo/team-emails/pull/203). As before I've deliberately kept this short and personalised so it comes across more as a direct email than a mailshot. I'll still send it from teams@.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
