### PR TITLE
Add a reminder email about the Virtual League

### DIFF
--- a/SR2025/2025-01-29-virtual-league-reminder.md
+++ b/SR2025/2025-01-29-virtual-league-reminder.md
@@ -1,0 +1,69 @@
+---
+to: SR2025 teams
+subject: SR2025 Virtual League
+---
+
+Hi,
+
+With a little over half of the competition year now complete we hope your robots are progressing well.
+
+## Virtual League
+
+The [Virtual League][virtual-league] is the first stage of the SR2025 league.
+
+This is the first test of your team's coding skills, pushing their virtual robot
+to the limit, competing against other teams in a virtual arena and offering
+valuable experience in real matches. Points earned in the Virtual League are
+part of the main league, so they could make all the difference at the
+physical league.
+
+Your team must submit their code **two days before**, by 6pm GMT on Thursday 6th
+February via the code submitter: <https://studentrobotics.org/code-submitter/>.
+Your team can login using your three letter acronym ({TLA}) as the
+username and the password is the same as the password your team used to enter
+Discord: `{DiscordPassword}`.
+
+Code should be [submitted][code-submitter-docs] as a *zip archive* containing at
+least a `robot.py` file in the root of the archive. Your team can make as many
+submissions as they like, with the last one before the submission deadline being
+used. This allows them to continue working on their code even after having made
+an initial submission.
+
+There will be four appearances per team in the Virtual League, with each Virtual
+League match being worth half a Main League match. Only teams who submit code
+before the deadline will have appearances in the Virtual League. To ensure your
+team does not miss out on this opportunity for points, be sure that they [submit
+some code][code-submitter-docs] before then.
+
+The matches will be broadcast live on **Saturday 8th March 2025 at 1pm GMT** via
+a [livestream][virtual-league-livestream] on our YouTube channel.
+
+## Tech Days
+
+As a reminder, we also have a Tech Day coming up shortly after the Virtual League.
+This is in Horsham on [**Saturday 15th February**][horsham-tech-day-february].
+
+[Tech Days][tech-days] are opportunities for teams to spend a whole day working on their robot with lots of help available -- from a mix of long-experienced volunteers and more recent ex-competitors. They're also an opportunity to see how other teams are doing or get more direct help with your robots.
+
+We provide a space for you to work in, with power and internet access, as well as volunteers able to help you with your kits and hands-on guidance with your robots.
+
+There are two Tech Days left this year:
+
+* [**15th February 2025** - at Red River Software in Horsham][horsham-tech-day-february]
+* [**8th March 2025** - at Raspberry Pi Foundation in Cambridge][cambridge-tech-day-march]
+
+If you're interested in attending any of these events, please **[sign up to Tech Days][tech-day-signup]**.
+Volunteers may also be around virtually on these days for support, should you not be able to attend any events in person.
+
+For the February tech day, the deadline is Friday 7th February 2025 for you to [let us know][tech-day-signup] that you'd like to attend.
+
+-- Student Robotics
+
+
+[horsham-tech-day-february]: https://studentrobotics.org/events/sr2025/horsham-tech-day-february
+[cambridge-tech-day-march]: https://studentrobotics.org/events/sr2025/cambridge-tech-day-march
+[virtual-league]: https://studentrobotics.org/events/sr2025/virtual-competition
+[virtual-league-livestream]: https://www.youtube.com/live/p0KxrRNTGBs
+[code-submitter-docs]: https://studentrobotics.org/docs/tutorials/code_submitter
+[tech-days]: https://studentrobotics.org/docs/robots_101/tech_days
+[tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9

--- a/SR2025/2025-01-29-virtual-league-reminder.md
+++ b/SR2025/2025-01-29-virtual-league-reminder.md
@@ -14,8 +14,8 @@ The [Virtual League][virtual-league] is the first stage of the SR2025 league.
 This is the first test of your team's coding skills, pushing their virtual robot
 to the limit, competing against other teams in a virtual arena and offering
 valuable experience in real matches. Points earned in the Virtual League are
-part of the main league, so they could make all the difference at the
-physical league.
+part of the overall league, so they could make all the difference at the
+physical competition.
 
 Your team must submit their code **two days before**, by 6pm GMT on Thursday 6th
 February via the code submitter: <https://studentrobotics.org/code-submitter/>.

--- a/SR2025/2025-01-29-virtual-league-reminder.md
+++ b/SR2025/2025-01-29-virtual-league-reminder.md
@@ -19,9 +19,9 @@ physical league.
 
 Your team must submit their code **two days before**, by 6pm GMT on Thursday 6th
 February via the code submitter: <https://studentrobotics.org/code-submitter/>.
-Your team can login using your three letter acronym ({TLA}) as the
+Your team can login using your three letter acronym (`{TLA}`) as the
 username and the password is the same as the password your team used to enter
-Discord: `{DiscordPassword}`.
+Discord: `{DiscordPassword}`. Both the username and password are case sensitive.
 
 Code should be [submitted][code-submitter-docs] as a *zip archive* containing at
 least a `robot.py` file in the root of the archive. Your team can make as many

--- a/SR2025/2025-01-29-virtual-league-reminder.md
+++ b/SR2025/2025-01-29-virtual-league-reminder.md
@@ -19,9 +19,14 @@ physical competition.
 
 Your team must submit their code **two days before**, by 6pm GMT on Thursday 6th
 February via the code submitter: <https://studentrobotics.org/code-submitter/>.
-Your team can login using your three letter acronym (`{TLA}`) as the
+Your team can login using your three letter acronym as the
 username and the password is the same as the password your team used to enter
-Discord: `{DiscordPassword}`. Both the username and password are case sensitive.
+Discord:
+
+username:  **`{TLA}`**\
+password: **`{DiscordPassword}`**
+
+Both the username and password are case sensitive.
 
 Code should be [submitted][code-submitter-docs] as a *zip archive* containing at
 least a `robot.py` file in the root of the archive. Your team can make as many

--- a/SR2025/2025-01-29-virtual-league-reminder.md
+++ b/SR2025/2025-01-29-virtual-league-reminder.md
@@ -42,6 +42,7 @@ a [livestream][virtual-league-livestream] on our YouTube channel.
 
 As a reminder, we also have a Tech Day coming up shortly after the Virtual League.
 This is in Horsham on [**Saturday 15th February**][horsham-tech-day-february].
+Space is limited at this venue, so be sure to sign up soon if you're interested.
 
 [Tech Days][tech-days] are opportunities for teams to spend a whole day working on their robot with lots of help available -- from a mix of long-experienced volunteers and more recent ex-competitors. They're also an opportunity to see how other teams are doing or get more direct help with your robots.
 


### PR DESCRIPTION
## Summary

This aims to remind teams that the Virtual League is happening and how to take part.

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand

This was built from a combination of [last year's email](https://github.com/srobo/team-emails/blob/main/SR2024/2024-01-17-virtual-comp-reminder.md) and this year's [January update](https://github.com/srobo/team-emails/blob/main/SR2025/2025-01-08-jan-update.md).