### PR TITLE
Add an update email for February

### DIFF
--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -31,8 +31,9 @@ This year the competition is being held at the University of Southampton on the 
 Your robot will compete in a number of league matches, used to seed the knockout stages, as well as having time to make improvements.
 You will have a pit area where you can work on improving your robot and there will be lots of Blueshirt volunteers around to support your team.
 
-If you haven't already done so now is a good time to plan your trip, including travel and accommodation for the weekend, and consider any paperwork which your institution may require.
-If you require a risk assessment for the event, please reach out and we will be happy to provide one.
+We realise organising these kinds of events can be complex for your institution, especially regarding travel and accommodation.
+To aid with the aspects within the venue we have prepared a [risk assessment][competition-risk-assessment] for the event itself.
+Please reach out if there's any additional information we can provide to make this easier.
 
 Guests are welcome in person at the competition and we'll be livestreaming the event so people can follow along at home.
 For those attending in person, the most exciting matches are usually those in the Knockouts on the Sunday afternoon.
@@ -52,5 +53,6 @@ We'll be sending out a dedicated email with further details for attendance at th
 [tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9
 [programme-competition]: https://studentrobotics.org/docs/robots_101/programme_structure#competition
 [competition-event]: https://studentrobotics.org/events/sr2025/competition/
+[competition-risk-assessment]: https://studentrobotics.org/resources/sr2025/risk-assessments/SR2025-Competition-Risk-Assessment.pdf
 [safety-regulations]: https://studentrobotics.org/docs/resources/2025/rulebook.html#safety-regulations
 [design-rules]: https://studentrobotics.org/docs/resources/2025/rulebook.html#design-rules

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -8,7 +8,7 @@ Hi,
 With the competition on the horizon we have a few updates and reminders for you:
 
 * The final [Tech Day][tech-days] of the year is in Cambridge, [on 8th March][cambridge-tech-day-march]
-* The [Competition][programme-competition] is under two months away
+* Please [confirm your attendance][competition-rsvp] at the [Competition][programme-competition]
 
 ## Cambridge Tech Day
 
@@ -43,7 +43,14 @@ This not only confirms that the robot satisfies our safety regulations, but also
 Some considerations are that the battery is well protected, the power button is accessible and that you have a way to mount the flag which will identify your robot during matches.
 Please make sure you are familiar with both our [design rules][design-rules] and [safety regulations][safety-regulations] which contain the full details.
 
-We'll be sending out a dedicated email with further details for attendance at the competition, including collecting information about the team you intend to bring, in the coming weeks.
+We're working hard getting the event ready for you.
+In order for us to cement our plans, we need to know roughly how large your team is and whether there are any special considerations we need to take for anyone who is coming.
+We understand you might not know exact details right now, so vague guesses are absolutely fine for now!
+You'll be able to edit your response until our shortly before the competition, after which point please email us if anything changes.
+
+Please [fill out your team details][competition-rsvp] this week.
+
+We'll be sending out a dedicated email with further details for attendance at the competition in the coming weeks.
 
 -- Student Robotics
 
@@ -52,6 +59,7 @@ We'll be sending out a dedicated email with further details for attendance at th
 [tech-days]: https://studentrobotics.org/docs/robots_101/tech_days
 [tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9
 [programme-competition]: https://studentrobotics.org/docs/robots_101/programme_structure#competition
+[competition-rsvp]: https://forms.gle/TTWgDCKS2hWcEUSE8
 [competition-event]: https://studentrobotics.org/events/sr2025/competition/
 [competition-risk-assessment]: https://studentrobotics.org/resources/sr2025/risk-assessments/SR2025-Competition-Risk-Assessment.pdf
 [safety-regulations]: https://studentrobotics.org/docs/resources/2025/rulebook.html#safety-regulations

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -71,4 +71,4 @@ In the meanwhile, if you have any questions or concerns feel free to [email us][
 [competition-risk-assessment]: https://studentrobotics.org/resources/sr2025/risk-assessments/SR2025-Competition-Risk-Assessment.pdf
 [safety-regulations]: https://studentrobotics.org/docs/resources/2025/rulebook.html#safety-regulations
 [design-rules]: https://studentrobotics.org/docs/resources/2025/rulebook.html#design-rules
-[teams-email]: mailto: teams@studentrobotics.org
+[teams-email]: mailto:teams@studentrobotics.org

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -21,7 +21,7 @@ There is one final Tech Day left this year, on [**8th March 2025** - at Raspberr
 There are still plenty of spaces available, so if you're interested in attending please **[sign up][tech-day-signup]**.
 Volunteers may also be around virtually for support, should you not be able to attend the Tech Day in person.
 
-For this Tech Day, the deadline is Friday 28th February 2025 for you to [let us know][tech-day-signup] that you'd like to attend.
+For this Tech Day, the deadline for you to [let us know][tech-day-signup] that you'd like to attend is Friday 28th February 2025.
 
 ## Competition
 

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -1,0 +1,56 @@
+---
+to: SR2025 teams
+subject: SR2025 February Update
+---
+
+Hi,
+
+With the competition on the horizon we have a few updates and reminders for you:
+
+* The final [Tech Day][tech-days] of the year is in Cambridge, [on 8th March][cambridge-tech-day-march]
+* The [Competition][programme-competition] is under two months away
+
+## Cambridge Tech Day
+
+[Tech Days][tech-days] are opportunities for teams to spend a whole day working on their robot with lots of help available -- from a mix of long-experienced volunteers and more recent ex-competitors. They're also an opportunity to see how other teams are doing or get more direct help with your robot.
+
+We provide a space for you to work in, with power and internet access, as well as volunteers able to help you with your kits and hands-on guidance with your robot.
+
+There is one final Tech Day left this year, on [**8th March 2025** - at Raspberry Pi Foundation in Cambridge][cambridge-tech-day-march].
+
+There are still plenty of spaces available, so if you're interested in attending please **[sign up][tech-day-signup]**.
+Volunteers may also be around virtually for support, should you not be able to attend the Tech Day in person.
+
+For this Tech Day, the deadline is Friday 28th February 2025 for you to [let us know][tech-day-signup] that you'd like to attend.
+
+## Competition
+
+As you are hopefully aware, the [Competition][programme-competition] is a two day event and is the culmination of all your team's hard work over the past six months.
+This year the competition is being held at the University of Southampton on the weekend of [**Saturday 12th April** and **Sunday 13th April**][competition-event].
+
+Your robot will compete in a number of league matches, used to seed the knockout stages, as well as having time to make improvements.
+You will have a pit area where you can work on improving your robot and there will be lots of Blueshirt volunteers around to support your team.
+
+If you haven't already done so now is a good time to plan your trip, including travel and accommodation for the weekend, and consider any paperwork which your institution may require.
+If you require a risk assessment for the event, please reach out and we will be happy to provide one.
+
+Guests are welcome in person at the competition and we'll be livestreaming the event so people can follow along at home.
+For those attending in person, the most exciting matches are usually those in the Knockouts on the Sunday afternoon.
+
+At the competition, all robots undergo a safety check.
+This not only confirms that the robot satisfies our safety regulations, but also the rules.
+Some considerations are that the battery is well protected, the power button is accessible and that you have a way to mount the flag which will identify your robot during matches.
+Please make sure you are familiar with both our [design rules][design-rules] and [safety regulations][safety-regulations] which contain the full details.
+
+We'll be sending out a dedicated email with further details for attendance at the competition, including collecting information about the team you intend to bring, in the coming weeks.
+
+-- Student Robotics
+
+
+[cambridge-tech-day-march]: https://studentrobotics.org/events/sr2025/cambridge-tech-day-march
+[tech-days]: https://studentrobotics.org/docs/robots_101/tech_days
+[tech-day-signup]: https://forms.gle/SpZnqpUAaRbxwy2C9
+[programme-competition]: https://studentrobotics.org/docs/robots_101/programme_structure#competition
+[competition-event]: https://studentrobotics.org/events/sr2025/competition/
+[safety-regulations]: https://studentrobotics.org/docs/resources/2025/rulebook.html#safety-regulations
+[design-rules]: https://studentrobotics.org/docs/resources/2025/rulebook.html#design-rules

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -50,7 +50,7 @@ Please make sure you are familiar with both our [design rules][design-rules] and
 We're working hard getting the event ready for you.
 In order for us to cement our plans, we need to know roughly how large your team is and whether there are any special considerations we need to take for anyone who is coming.
 We understand you might not know exact details right now, so vague guesses are absolutely fine for now!
-You'll be able to edit your response until our shortly before the competition, after which point please [email us][teams-email] if anything changes.
+You'll be able to edit your response until the end of March, after which point please [email us][teams-email] if anything changes.
 
 Please **[fill out your team details][competition-rsvp]** this week.
 

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -28,6 +28,8 @@ For this Tech Day, the deadline for you to [let us know][tech-day-signup] that y
 As you are hopefully aware, the [Competition][programme-competition] is a two day event and is the culmination of all your team's hard work over the past six months.
 This year the competition is being held at the University of Southampton on the weekend of [**Saturday 12th April** and **Sunday 13th April**][competition-event].
 
+### Helping you plan
+
 Your robot will compete in a number of league matches, used to seed the knockout stages, as well as having time to make improvements.
 You will have a pit area where you can work on improving your robot and there will be lots of Blueshirt volunteers around to support your team.
 
@@ -43,14 +45,19 @@ This not only confirms that the robot satisfies our safety regulations, but also
 Some considerations are that the battery is well protected, the power button is accessible and that you have a way to mount the flag which will identify your robot during matches.
 Please make sure you are familiar with both our [design rules][design-rules] and [safety regulations][safety-regulations] which contain the full details.
 
+### Helping us plan
+
 We're working hard getting the event ready for you.
 In order for us to cement our plans, we need to know roughly how large your team is and whether there are any special considerations we need to take for anyone who is coming.
 We understand you might not know exact details right now, so vague guesses are absolutely fine for now!
 You'll be able to edit your response until our shortly before the competition, after which point please email us if anything changes.
 
-Please [fill out your team details][competition-rsvp] this week.
+Please **[fill out your team details][competition-rsvp]** this week.
 
-We'll be sending out a dedicated email with further details for attendance at the competition in the coming weeks.
+### Further details
+
+We'll be sending out a dedicated email with further details about the competition in the coming weeks.
+In the meanwhile, if you have any questions or concerns feel free to [email us][teams-email].
 
 -- Student Robotics
 
@@ -64,3 +71,4 @@ We'll be sending out a dedicated email with further details for attendance at th
 [competition-risk-assessment]: https://studentrobotics.org/resources/sr2025/risk-assessments/SR2025-Competition-Risk-Assessment.pdf
 [safety-regulations]: https://studentrobotics.org/docs/resources/2025/rulebook.html#safety-regulations
 [design-rules]: https://studentrobotics.org/docs/resources/2025/rulebook.html#design-rules
+[teams-email]: mailto: teams@studentrobotics.org

--- a/SR2025/2025-02-24-feb-update.md
+++ b/SR2025/2025-02-24-feb-update.md
@@ -50,7 +50,7 @@ Please make sure you are familiar with both our [design rules][design-rules] and
 We're working hard getting the event ready for you.
 In order for us to cement our plans, we need to know roughly how large your team is and whether there are any special considerations we need to take for anyone who is coming.
 We understand you might not know exact details right now, so vague guesses are absolutely fine for now!
-You'll be able to edit your response until our shortly before the competition, after which point please email us if anything changes.
+You'll be able to edit your response until our shortly before the competition, after which point please [email us][teams-email] if anything changes.
 
 Please **[fill out your team details][competition-rsvp]** this week.
 


### PR DESCRIPTION
## Summary

This is likely the last generic update email we'll send as very soon the only remaining event will be the competition.

The details here around the competition are deliberately very high level -- our goal at this point is to provide general info rather than full details. The next email will provide deeper details as well as seeking RSVPs.

Supports https://github.com/srobo/tasks/issues/1426, but does not close it

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
