### PR TITLE
Add announcement email for SR2026

### DIFF
--- a/SR2026/2025-09-09-competition-announcement.md
+++ b/SR2026/2025-09-09-competition-announcement.md
@@ -25,7 +25,7 @@ of September. Places are limited, so sign up soon to avoid disappointment.
 As usual we will loan competing teams a [kit][kit] of parts to help build their
 robots. Teams can collect their kit from the Kickstart event, so they can get started straight away. If you're unable to attend in person, we aim to ship your kit to you prior to the event. In order to manage our rising costs, this year you will need to cover the cost of postage for your kit if you are not attending Kickstart in person. This will be around £15 and we will send an invoice prior to shipping your kit. We'll confirm further details about this once you've registered for the year.
 
-Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website. We soon be releasing some pre-Kickstart activities which will enable anyone to start learning about robotics and our simulator.
+Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website. We soon be releasing some pre-Kickstart activities which will enable everyone to start learning about robotics and our simulator, instructions for [setting up the simulator are available in our docs][simulator-setup].
 
 We look forward to seeing your teams,
 
@@ -40,3 +40,4 @@ Regards,
 [kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
 [kit]: https://studentrobotics.org/docs/kit/
 [sr2025-blog-post]: https://studentrobotics.org/blog/2025-04-24-ths-win-sr2025/
+[simulator-setup]: https://studentrobotics.org/docs/simulator/setting_up_simulator

--- a/SR2026/2025-09-09-competition-announcement.md
+++ b/SR2026/2025-09-09-competition-announcement.md
@@ -20,15 +20,12 @@ on Saturday 8th November. We will also be live-streaming the event for those
 unable to attend in person. We expect to confirm places towards the end
 of September. Places are limited, so sign up soon to avoid disappointment.
 
+  [Sign up to SR2026][signup-form]
+
 As usual we will loan competing teams a [kit][kit] of parts to help build their
 robots. Teams can collect their kit from the Kickstart event, so they can get started straight away. If you're unable to attend in person, we aim to ship your kit to you prior to the event. We'll confirm further details about this once you've registered for the year.
 
-We have also created some [pre-Kickstart activities][pre-kickstart-activities]
-which enable anyone to start learning about robotics and our simulator.
-
-  [Sign up to SR2026][signup-form]
-
-Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website.
+Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website. We soon be releasing some pre-Kickstart activities which will enable anyone to start learning about robotics and our simulator.
 
 We look forward to seeing your teams,
 
@@ -42,5 +39,4 @@ Regards,
 [team-supervisor]: https://studentrobotics.org/docs/robots_101/team_supervisor
 [kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
 [kit]: https://studentrobotics.org/docs/kit/
-[pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities
 [sr2025-blog-post]: https://studentrobotics.org/blog/2025-04-24-ths-win-sr2025/

--- a/SR2026/2025-09-09-competition-announcement.md
+++ b/SR2026/2025-09-09-competition-announcement.md
@@ -31,7 +31,7 @@ We look forward to seeing your teams,
 
 Regards,
 
--- SR Competition Committee
+-- SR Committee
 
 [announcement]: https://studentrobotics.org/blog/2025-09-06-sr2026-registration-open/
 [programme-structure]: https://studentrobotics.org/docs/robots_101/programme_structure

--- a/SR2026/2025-09-09-competition-announcement.md
+++ b/SR2026/2025-09-09-competition-announcement.md
@@ -1,0 +1,46 @@
+---
+to: Potential team supervisors and SR2025 teams
+subject: Announcing Student Robotics 2026!
+preview: |
+  Sign up to Student Robotics 2026 and get started with our pre-kickstart activities!
+---
+
+Hi,
+
+We're pleased to [announce][announcement] that registration for Student Robotics
+2026 is now open. The [programme][programme-structure] will run from our Kickstart event in November to the in-person competition over two days around Easter 2026.
+
+If you would like to compete, please complete the [signup form][signup-form]
+with the details of your team. Entries must be made by a responsible adult on
+behalf of a team -- we call this role a [team supervisor][team-supervisor]. All
+future emails about SR2026 will be sent to the details you provide via the form.
+
+This year we're hosting [Kickstart][kickstart] at the University of Southampton,
+on Saturday 8th November. We will also be live-streaming the event for those
+unable to attend in person. We expect to confirm places towards the end
+of September. Places are limited, so sign up soon to avoid disappointment.
+
+As usual we will loan competing teams a [kit][kit] of parts to help build their
+robots. Teams can collect their kit from the Kickstart event, so they can get started straight away. If you're unable to attend in person, we aim to ship your kit to you prior to the event. We'll confirm further details about this once you've registered for the year.
+
+We have also created some [pre-Kickstart activities][pre-kickstart-activities]
+which enable anyone to start learning about robotics and our simulator.
+
+  [Sign up to SR2026][signup-form]
+
+Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website.
+
+We look forward to seeing your teams,
+
+Regards,
+
+-- SR Competition Committee
+
+[announcement]: https://studentrobotics.org/blog/2025-09-06-sr2026-registration-open/
+[programme-structure]: https://studentrobotics.org/docs/robots_101/programme_structure
+[signup-form]: https://forms.gle/bPnLVwsJ8xQLVaoQ8
+[team-supervisor]: https://studentrobotics.org/docs/robots_101/team_supervisor
+[kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
+[kit]: https://studentrobotics.org/docs/kit/
+[pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities
+[sr2025-blog-post]: https://studentrobotics.org/blog/2025-04-24-ths-win-sr2025/

--- a/SR2026/2025-09-09-competition-announcement.md
+++ b/SR2026/2025-09-09-competition-announcement.md
@@ -23,7 +23,7 @@ of September. Places are limited, so sign up soon to avoid disappointment.
   [Sign up to SR2026][signup-form]
 
 As usual we will loan competing teams a [kit][kit] of parts to help build their
-robots. Teams can collect their kit from the Kickstart event, so they can get started straight away. If you're unable to attend in person, we aim to ship your kit to you prior to the event. We'll confirm further details about this once you've registered for the year.
+robots. Teams can collect their kit from the Kickstart event, so they can get started straight away. If you're unable to attend in person, we aim to ship your kit to you prior to the event. In order to manage our rising costs, this year you will need to cover the cost of postage for your kit if you are not attending Kickstart in person. This will be around £15 and we will send an invoice prior to shipping your kit. We'll confirm further details about this once you've registered for the year.
 
 Further details about what to expect from the [Kickstart event][kickstart], as well as details from [last year's competition][sr2025-blog-post] can be found on our website. We soon be releasing some pre-Kickstart activities which will enable anyone to start learning about robotics and our simulator.
 


### PR DESCRIPTION
## Summary

Announce the SR2026 competition to teams.

## Checklist

<!-- Please keep all of these, ~strike~ any which don't apply -->

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand
- [ ] Merge https://github.com/srobo/website/pull/620/