### PR TITLE
Add SR2026 place confirmation email

### DIFF
--- a/SR2026/2025-10-01-confirm-places.md
+++ b/SR2026/2025-10-01-confirm-places.md
@@ -29,7 +29,7 @@ form, please let us know so we can plan accordingly.
 As usual we will loan your team a [kit][kit] of parts to help build your robot. Since you're attending kickstart, you'll be able to collect it there. We look forward to seeing you there.
 
 At the event, you'll need to sign a Kit Disclaimer form (PDF attached). This disclaimer covers the terms and conditions
-under which you may use the kit and outlines the limits of our responsibilities. If you can read and sign it before the event, it will speed up issuing your kit.
+under which you may use the kit and outlines the limits of our responsibilities. If you can read, sign it and return before the event, it will speed up issuing your kit.
 
 {% else %}
 
@@ -50,7 +50,7 @@ up:
 
     TODO_SHIPPING_ADDRESS
 
-We will send you an email with a tracking link once your kit is on its way.
+We will send you an email with a tracking link once your kit is on its way. Disclaimers and invoices returned after Friday 31st October may result in your kit arriving after kickstart.
 
 {% endif %}
 

--- a/SR2026/2025-10-01-confirm-places.md
+++ b/SR2026/2025-10-01-confirm-places.md
@@ -56,9 +56,7 @@ We will send you an email with a tracking link once your kit is on its way. Disc
 
 ## Looking ahead
 
-If your team would like to get started before Kickstart, we have prepared some [pre-Kickstart activities][pre-kickstart-activities] which
-introduce robotics and our simulator without needing the kit. If your team needs
-any assistance with these activities, please encourage them to post in Discord once it's made available.
+If your team would like to get started before Kickstart, the [simulator][simulator] is available to start playing around with, as well as the [API documentation][docs]. If your team needs any assistance with these, please encourage them to post in Discord once it's made available.
 
 At various points in the year we will have a number of "[Tech Days][tech-days]"
 at locations around the UK. These provide an opportunity for your team to get
@@ -74,5 +72,6 @@ We look forward to seeing you at Kickstart!
 [team-supervisor]: https://studentrobotics.org/docs/robots_101/team_supervisor
 [kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
 [kit]: https://studentrobotics.org/docs/kit/
-[pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities
 [mailto-teams]: mailto:teams@studentrobotics.org
+[docs]: https://studentrobotics.org/docs/
+[simulator]: https://studentrobotics.org/docs/simulator/

--- a/SR2026/2025-10-01-confirm-places.md
+++ b/SR2026/2025-10-01-confirm-places.md
@@ -12,7 +12,7 @@ You're in! We're happy to confirm you've got a place at Student Robotics 2026!
 Thank you for taking on the role of a [team supervisor][team-supervisor] for
 your team. If you have any questions about the [competition programme][programme-structure],
 building a robot or anything else, please feel free to reach out to us in the
-`#team-supervisors` channel on [Discord][discord] or email us at
+`#team-supervisors` channel on Discord once it's available or email us at
 <teams@studentrobotics.org>.
 
 This year we're hosting [Kickstart][kickstart] at the University of Southampton,
@@ -54,51 +54,11 @@ We will send you an email with a tracking link once your kit is on its way. Disc
 
 {% endif %}
 
-## Discord
-
-To support your team throughout the year and enable you to share experiences
-with other teams we have a [Discord][discord] server. This is the primary
-communication method for competitor support, enabling competitors to get support
-directly from our volunteer mentors at any time.
-
-The invite link is <https://discord.com/invite/TODO_REPLACE_DISCORD_LINK_BEFORE_SENDING>.
-
-If you don't already have a Discord account, you can register an account for
-free. Accounts should be per individual and not shared with others.
-
-Within Discord there are a number of shared channels, which everyone has access
-to. Additionally there is a channel which is just for your team, which can only
-be accessed by yourself, your competitors, and our Blueshirt volunteers. Your
-team's channel is called `#team-TODO_REPLACE_TLA_BEFORE_SENDING`.
-
-Upon joining the server users will need to provide a password to gain the
-correct permissions. The password is used to identify which team a user is from,
-so do not share to those outside your team. Please share both the invite link and
-the relevant password with your competitors.
-
-For your team, the password is: TODO_REPLACE_PASSWORD_BEFORE_SENDING
-
-More information on this can be found in [the docs][discord].
-
-Additionally, we like to make sure we are aware which members are volunteers,
-competitors and team supervisors. If you provided your Discord username when you
-signed up we will assign you the 'Team Supervisor' role once you've joined. If
-you didn't, then please reply to this email with your Discord username once you
-have joined the server and we will add the appropriate roles.
-
-Whilst most of the discussions and support will be happening on Discord, if you
-are unable to or do not wish to create an account with Discord you can still
-[contact us][mailto-teams] for support, however the response times will be
-longer. Additionally for SR2026 some elements of the competition will require
-posting to Discord, so please do encourage your team to join. If you are unable
-to do this, please [let us know][mailto-teams] so we can work out alternative
-ways to accommodate your team.
-
 ## Looking ahead
 
 If your team would like to get started before Kickstart, we have prepared some [pre-Kickstart activities][pre-kickstart-activities] which
 introduce robotics and our simulator without needing the kit. If your team needs
-any assistance with these activities, please encourage them to post in Discord.
+any assistance with these activities, please encourage them to post in Discord once it's made available.
 
 At various points in the year we will have a number of "[Tech Days][tech-days]"
 at locations around the UK. These provide an opportunity for your team to get
@@ -113,7 +73,6 @@ We look forward to seeing you at Kickstart!
 [tech-days]: https://studentrobotics.org/docs/robots_101/tech_days
 [team-supervisor]: https://studentrobotics.org/docs/robots_101/team_supervisor
 [kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
-[discord]: https://studentrobotics.org/docs/tutorials/discord
 [kit]: https://studentrobotics.org/docs/kit/
 [pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities
 [mailto-teams]: mailto:teams@studentrobotics.org

--- a/SR2026/2025-10-01-confirm-places.md
+++ b/SR2026/2025-10-01-confirm-places.md
@@ -29,7 +29,7 @@ form, please let us know so we can plan accordingly.
 As usual we will loan your team a [kit][kit] of parts to help build your robot. Since you're attending kickstart, you'll be able to collect it there. We look forward to seeing you there.
 
 At the event, you'll need to sign a Kit Disclaimer form (PDF attached). This disclaimer covers the terms and conditions
-under which you may use the kit and outlines the limits of our responsibilities. If you can read, sign it and return before the event, it will speed up issuing your kit.
+under which you may use the kit and outlines the limits of our responsibilities. Please read, sign and return the form before the event, as it will speed up issuing your kit.
 
 {% else %}
 

--- a/SR2026/2025-10-01-confirm-places.md
+++ b/SR2026/2025-10-01-confirm-places.md
@@ -1,0 +1,119 @@
+---
+to: Student Robotics 2026
+subject: Confirming your place at Student Robotics 2026
+attachments:
+  - Kit Disclaimer (PDF): https://drive.google.com/file/d/1dZAawbzQwh0peaZRpesL9Up5CzOr--Ec/view
+---
+
+Hi,
+
+You're in! We're happy to confirm you've got a place at Student Robotics 2026!
+
+Thank you for taking on the role of a [team supervisor][team-supervisor] for
+your team. If you have any questions about the [competition programme][programme-structure],
+building a robot or anything else, please feel free to reach out to us in the
+`#team-supervisors` channel on [Discord][discord] or email us at
+<teams@studentrobotics.org>.
+
+This year we're hosting [Kickstart][kickstart] at the University of Southampton,
+on Saturday 8th November. We will also be live-streaming the event if you are
+unable to attend in person. In that case we encourage that your team meet up to
+watch the presentations, get to know each other and start working together on
+the kit. If your plans for Kickstart change from what you put on the sign-up
+form, please let us know so we can plan accordingly.
+
+{% if attending_kickstart %}
+
+## Kit Collection
+
+As usual we will loan your team a [kit][kit] of parts to help build your robot. Since you're attending kickstart, you'll be able to collect it there. We look forward to seeing you there.
+
+At the event, you'll need to sign a Kit Disclaimer form (PDF attached). This disclaimer covers the terms and conditions
+under which you may use the kit and outlines the limits of our responsibilities. If you can read and sign it before the event, it will speed up issuing your kit.
+
+{% else %}
+
+## Kit Shipping
+
+As usual we will loan your team a [kit][kit] of parts to help build your robot.
+This year we hope to send out kits shortly before Kickstart.
+
+In order to enable us to send out your kit you need to agree to our _kit
+disclaimer_ (PDF attached). This disclaimer covers the terms and conditions
+under which you may use the kit and outlines the limits of our responsibilities.
+Please **sign it, scan it and email it back to us**.
+
+As mentioned in our announcement email, to manage our rising costs, this year you will need to cover the cost of postage for your kit if you are not attending Kickstart in person. Please see the attached invoice with further information.
+
+We will be sending your kit to the shipping address you provided when you signed
+up:
+
+    TODO_SHIPPING_ADDRESS
+
+We will send you an email with a tracking link once your kit is on its way.
+
+{% endif %}
+
+## Discord
+
+To support your team throughout the year and enable you to share experiences
+with other teams we have a [Discord][discord] server. This is the primary
+communication method for competitor support, enabling competitors to get support
+directly from our volunteer mentors at any time.
+
+The invite link is <https://discord.com/invite/TODO_REPLACE_DISCORD_LINK_BEFORE_SENDING>.
+
+If you don't already have a Discord account, you can register an account for
+free. Accounts should be per individual and not shared with others.
+
+Within Discord there are a number of shared channels, which everyone has access
+to. Additionally there is a channel which is just for your team, which can only
+be accessed by yourself, your competitors, and our Blueshirt volunteers. Your
+team's channel is called `#team-TODO_REPLACE_TLA_BEFORE_SENDING`.
+
+Upon joining the server users will need to provide a password to gain the
+correct permissions. The password is used to identify which team a user is from,
+so do not share to those outside your team. Please share both the invite link and
+the relevant password with your competitors.
+
+For your team, the password is: TODO_REPLACE_PASSWORD_BEFORE_SENDING
+
+More information on this can be found in [the docs][discord].
+
+Additionally, we like to make sure we are aware which members are volunteers,
+competitors and team supervisors. If you provided your Discord username when you
+signed up we will assign you the 'Team Supervisor' role once you've joined. If
+you didn't, then please reply to this email with your Discord username once you
+have joined the server and we will add the appropriate roles.
+
+Whilst most of the discussions and support will be happening on Discord, if you
+are unable to or do not wish to create an account with Discord you can still
+[contact us][mailto-teams] for support, however the response times will be
+longer. Additionally for SR2026 some elements of the competition will require
+posting to Discord, so please do encourage your team to join. If you are unable
+to do this, please [let us know][mailto-teams] so we can work out alternative
+ways to accommodate your team.
+
+## Looking ahead
+
+If your team would like to get started before Kickstart, we have prepared some [pre-Kickstart activities][pre-kickstart-activities] which
+introduce robotics and our simulator without needing the kit. If your team needs
+any assistance with these activities, please encourage them to post in Discord.
+
+At various points in the year we will have a number of "[Tech Days][tech-days]"
+at locations around the UK. These provide an opportunity for your team to get
+hands-on help from our volunteer mentors, make progress on their robot, and meet
+other teams. We'll let you know once we have more details about these events.
+
+We look forward to seeing you at Kickstart!
+
+-- Student Robotics
+
+[programme-structure]: https://studentrobotics.org/docs/robots_101/programme_structure
+[tech-days]: https://studentrobotics.org/docs/robots_101/tech_days
+[team-supervisor]: https://studentrobotics.org/docs/robots_101/team_supervisor
+[kickstart]: https://studentrobotics.org/events/sr2026/kickstart/
+[discord]: https://studentrobotics.org/docs/tutorials/discord
+[kit]: https://studentrobotics.org/docs/kit/
+[pre-kickstart-activities]: https://studentrobotics.org/docs/competitor_resources/pre_kickstart_activities
+[mailto-teams]: mailto:teams@studentrobotics.org

--- a/SR2026/2025-10-01-reject-places.md
+++ b/SR2026/2025-10-01-reject-places.md
@@ -1,0 +1,32 @@
+---
+to: Student Robotics 2026 rejections
+subject: Student Robotics 2026 is sadly full
+---
+Hi,
+
+We had a lot more interest in Student Robotics 2026 than we had places
+available. This has meant that unfortunately we're unable to offer you a place
+this year.
+
+We realise this is disappointing (we're disappointed too!), however we are
+limited by the number of kits we have and by the size of the venue. We are
+always looking for ways to support more teams and hope to be able to do so in
+future.
+
+{% if team_is_on_waiting_list %}
+We've put you on our waiting list so if we have any early drop outs we will be
+sure to let you know. You may be able to take their place, but we cannot promise
+anything. Let us know if you don't want to be on the waiting list.
+
+If we are able to offer you a place, we'll let you know by Friday 31th October
+at the latest (that's two weeks after Kickstart).
+{% endif %}
+
+We hope you follow the competition on social media, and subscribe to our
+[mailing list](https://studentrobotics.org/compete/) to be the first to know
+when places open for Student Robotics 2027.
+
+Thanks again for your interest, and we hope to see you next year.
+
+Thanks,\
+-- Student Robotics

--- a/SR2026/2025-10-01-reject-places.md
+++ b/SR2026/2025-10-01-reject-places.md
@@ -18,7 +18,7 @@ We've put you on our waiting list so if we have any early drop outs we will be
 sure to let you know. You may be able to take their place, but we cannot promise
 anything. Let us know if you don't want to be on the waiting list.
 
-If we are able to offer you a place, we'll let you know by Friday 31th October
+If we are able to offer you a place, we'll let you know by Friday 21st November
 at the latest (that's two weeks after Kickstart).
 {% endif %}
 


### PR DESCRIPTION
## Summary

Add email sent to teams who have a place in SR2026

## Checklist

- [x] Has front-matter (`to` and `subject`)
- [x] Compared to a similar email from the previous year
- [x] Ensured there's enough context for a rookie team to understand

## Outstanding

- [x] ~~Set up Discord~~
- [ ] Create invoice template
- [x] Pre-kickstart activities
- [x] Include deadlines on responses