### PR TITLE
Add email to recover kits

### DIFF
--- a/SR2026/2026-04-29-kit-recovery.md
+++ b/SR2026/2026-04-29-kit-recovery.md
@@ -24,3 +24,5 @@ Please insure the kit during shipping and use a courier which supports tracking,
 Further details about shipping can be found [in the docs](https://studentrobotics.org/docs/kit/return).
 
 If you have any questions, please let us know as soon as possible!
+
+-- Student Robotics

--- a/SR2026/2026-04-29-kit-recovery.md
+++ b/SR2026/2026-04-29-kit-recovery.md
@@ -21,7 +21,7 @@ Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.o
 
 Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
 
-Further details about shipping can be found [in the docs](https://studentrobotics.org/docs/kit/return).
+Further details about shipping can be found [in the docs](https://studentrobotics.org/docs/kit/return). Whilst you can use any courier, we used [UPS](https://www.ups.com/gb/en/home) to ship the kits to you.
 
 If you have any questions, please let us know as soon as possible!
 

--- a/SR2026/2026-04-29-kit-recovery.md
+++ b/SR2026/2026-04-29-kit-recovery.md
@@ -6,7 +6,7 @@ attachment: https://docs.google.com/document/d/1H7XzFhBYGa38i6BfsD6vJbLE-Wbk86a9
 
 Hello!
 
-According to our records, you still have a kit from this years competition. As the competition has ended, we would like this back! It's vitally important kit is returned promptly so we can test, repair and update it ready for the next event.
+According to our records, you still have a kit from this year's competition. As the competition has ended, we would like this back! It's vitally important kit is returned promptly so we can test, repair, and update it ready for the next event.
 
 Please securely pack the kit and ship it to our [postal address](https://studentrobotics.org/contact/). You can find a [list of the parts](https://studentrobotics.org/docs/kit/) to return on our website or as a checklist attached to this email.
 
@@ -14,7 +14,7 @@ Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.o
 
 ## How to ship your kit
 
-- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
+- Kits should be shipped in the white 18L Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
 - All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
 - Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
 - Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.

--- a/SR2026/2026-04-29-kit-recovery.md
+++ b/SR2026/2026-04-29-kit-recovery.md
@@ -1,0 +1,26 @@
+---
+to: Teams with outstanding kit
+subject: Outstanding kit from SR2026
+attachment: https://docs.google.com/document/d/1H7XzFhBYGa38i6BfsD6vJbLE-Wbk86a9U5cNI3OwATE/view
+---
+
+Hello!
+
+According to our records, you still have a kit from this years competition. As the competition has ended, we would like this back! It's vitally important kit is returned promptly so we can test, repair and update it ready for the next event.
+
+Please securely pack the kit and ship it to our [postal address](https://studentrobotics.org/contact/). You can find a [list of the parts](https://studentrobotics.org/docs/kit/) to return on our website or as a checklist attached to this email.
+
+Once you have dispatched it, please [let us know](mailto:teams@studentrobotics.org).
+
+## How to ship your kit
+
+- Kits should be shipped in the white 18l Really Useful Box (RUB). For extra protection, we recommend wrapping this in paper / cling film during shipping.
+- All parts of the kit should be suitably protected either in Jiffy bags or bubble wrap.
+- Damaged batteries must not be shipped. If you have concerns about your batteries, please contact us.
+- Any empty space in the box should be filled with paper or bubble wrap. Please don't use packing peanuts as they're messy.
+
+Please insure the kit during shipping and use a courier which supports tracking, to ensure the kit isn't lost.
+
+Further details about shipping can be found [in the docs](https://studentrobotics.org/docs/kit/return).
+
+If you have any questions, please let us know as soon as possible!


### PR DESCRIPTION
## Summary

We want the kits back.

This email will go to the teams listed here: https://github.com/srobo/kit-logistics/issues?q=is%3Aissue%20state%3Aopen%20label%3Adrop-out%20label%3A%22Y%3A%20SR2026%22

Teams who only returned part of their kits will need a slightly different email (listing the missing items), which will happen at a later date.

## Checklist

<!-- Please keep all of these, ~strike~ any which don't apply -->

- [ ] Has front-matter (`to` and `subject`)
- [ ] Compared to a similar email from the previous year
- [ ] Ensured there's enough context for a rookie team to understand
